### PR TITLE
Looks like a bug: Number of elements in an array can be less then number of items schemas:

### DIFF
--- a/src/jesse_schema_validator.hrl
+++ b/src/jesse_schema_validator.hrl
@@ -96,7 +96,6 @@
 -define(no_match,                    'no_match').
 -define(no_extra_properties_allowed, 'no_extra_properties_allowed').
 -define(no_extra_items_allowed,      'no_extra_items_allowed').
--define(not_enought_items,           'not_enought_items').
 -define(not_allowed,                 'not_allowed').
 -define(not_unique,                  'not_unique').
 -define(not_in_range,                'not_in_range').

--- a/src/jesse_validator_draft3.erl
+++ b/src/jesse_validator_draft3.erl
@@ -43,7 +43,6 @@
                     | ?no_match
                     | ?not_allowed
                     | ?not_divisible
-                    | ?not_enought_items
                     | ?not_found
                     | ?not_in_range
                     | ?wrong_length
@@ -557,9 +556,7 @@ check_items_array(Value, Items, State) ->
           ExtraSchemas = lists:duplicate(NExtra, AdditionalItems),
           Tuples = lists:zip(Value, lists:append(Items, ExtraSchemas)),
           check_items_fun(Tuples, State)
-      end;
-    NExtra when NExtra < 0 ->
-      handle_data_invalid(?not_enought_items, Value, State)
+      end
   end.
 
 %% @private

--- a/src/jesse_validator_draft3.erl
+++ b/src/jesse_validator_draft3.erl
@@ -556,7 +556,10 @@ check_items_array(Value, Items, State) ->
           ExtraSchemas = lists:duplicate(NExtra, AdditionalItems),
           Tuples = lists:zip(Value, lists:append(Items, ExtraSchemas)),
           check_items_fun(Tuples, State)
-      end
+      end;
+    NExtra when NExtra < 0 ->
+      Items1 = lists:sublist(Items, length(Value)),
+      check_items_fun(lists:zip(Value, Items1), State)
   end.
 
 %% @private

--- a/src/jesse_validator_draft4.erl
+++ b/src/jesse_validator_draft4.erl
@@ -566,7 +566,10 @@ check_items_array(Value, Items, State) ->
           ExtraSchemas = lists:duplicate(NExtra, AdditionalItems),
           Tuples = lists:zip(Value, lists:append(Items, ExtraSchemas)),
           check_items_fun(Tuples, State)
-      end
+      end;
+    NExtra when NExtra < 0 ->
+      Items1 = lists:sublist(Items, length(Value)),
+      check_items_fun(lists:zip(Value, Items1), State)
   end.
 
 %% @private

--- a/src/jesse_validator_draft4.erl
+++ b/src/jesse_validator_draft4.erl
@@ -54,7 +54,6 @@
                     | ?no_extra_items_allowed
                     | ?no_extra_properties_allowed
                     | ?no_match
-                    | ?not_enought_items
                     | ?not_found
                     | ?not_in_range
                     | ?not_multiple_of
@@ -567,9 +566,7 @@ check_items_array(Value, Items, State) ->
           ExtraSchemas = lists:duplicate(NExtra, AdditionalItems),
           Tuples = lists:zip(Value, lists:append(Items, ExtraSchemas)),
           check_items_fun(Tuples, State)
-      end;
-    NExtra when NExtra < 0 ->
-      handle_data_invalid(?not_enought_items, Value, State)
+      end
   end.
 
 %% @private


### PR DESCRIPTION
{
    "items": [ {}, {}, {} ],
    "additionalItems": false
}

With this schema, the following instances are valid:

[] (an empty array),
[ [ 1, 2, 3, 4 ], [ 5, 6, 7, 8 ] ],
[ 1, 2, 3 ];

http://json-schema.org/latest/json-schema-validation.html#anchor37