### PR TITLE
Fixed jesse_error spec

### DIFF
--- a/src/jesse.erl
+++ b/src/jesse.erl
@@ -126,7 +126,8 @@ load_schemas(Path, ParserFun, ValidationFun, MakeKeyFun) ->
 -spec validate( Schema :: any()
               , Data   :: json_term() | binary()
               ) -> {ok, json_term()}
-                 | jesse_error:error().
+                 | jesse_error:error()
+                 | jesse_database:error().
 validate(Schema, Data) ->
   validate(Schema, Data, []).
 
@@ -142,7 +143,8 @@ validate(Schema, Data) ->
               , Data     :: json_term() | binary()
               , Options  :: [{Key :: atom(), Data :: any()}]
               ) -> {ok, json_term()}
-                 | jesse_error:error().
+                 | jesse_error:error()
+                 | jesse_database:error().
 validate(Schema, Data, Options) ->
   try
     ParserFun  = proplists:get_value(parser_fun, Options, fun(X) -> X end),

--- a/src/jesse_database.erl
+++ b/src/jesse_database.erl
@@ -36,9 +36,17 @@
         ]).
 
 -export_type([ update_result/0
+             , error/0
              ]).
 
 -type update_result() :: ok | [fail()].
+
+-type error() :: {error, error_reason()}.
+
+-type error_reason() :: { 'database_error'
+                        , Key ::any()
+                        , 'schema_not_found'
+                        }.
 
 -type fail()          :: {file:filename(), file:date_time(), reason()}.
 -type reason()        :: term().


### PR DESCRIPTION
In this code:

```
case jesse:validate(DoctypeTag, DocJson) of
    {ok, _} -> ...
    {error, {database_error, _Schema, schema_not_found}} -> ...
end
```

Dialyzer shows:

```
The pattern {'error', {'database_error', _Schema, 'schema_not_found'}} can never match the type {'error',[{'schema_invalid',_,atom() | {atom(),_}} | {'data_invalid',_,atom() | {atom(),_},_,[binary()]}]}
```

But this error is real:

```erlang
1> jesse:validate(unknwon_key, <<"">>).
{error,{database_error,unknwon_key,schema_not_found}}
```
