### PR TITLE
Fixing a minor error with OTP 19.0's dialyzer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ sudo: false
 language:
   - erlang
 otp_release:
+  - 19.0
+  - 18.3
   - 18.2
   - 18.1
   - 18.0 #  - 17.5

--- a/src/jesse_state.erl
+++ b/src/jesse_state.erl
@@ -66,7 +66,7 @@
                                           jesse:json_term() |
                                           ?not_found
                                             )
-         , id                 :: binary()
+         , id                 :: binary() | 'undefined'
          }
        ).
 


### PR DESCRIPTION
It seems that OTP 19.0's dialyzer doesn't tolerate building records that
violate their specs any more; prior to this patch, it would raise the following
warnings:

```
jesse_cli.erl:61: The pattern {'ok', _} can never match the type {'error',_}
jesse_cli.erl:79: The pattern {'ok', _} can never match the type {'error',_}
jesse_schema_validator.erl:72: Function result/1 will never be called
jesse_state.erl:141: Record construction #state{current_path::[],error_list::[],id::'undefined'} violates the declared type of field id::binary()
jesse_state.erl:273: The pattern <'undefined', Id> can never match the type <binary() | [any()] | {'error',[any()],binary() | maybe_improper_list(binary() | maybe_improper_list(any(),binary() | []) | char(),binary() | [])} | {'incomplete',[any()],binary()},[binary() | maybe_improper_list(any(),binary() | []) | char()]>
jesse_tests_util.erl:85: The pattern {'ok', _} can never match the type {'error',_}
```