### PR TITLE
Load schemas on demand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## 1.5.0
+
+* Default schema loader now supports file: http: and https: URI schemes.
+  When a schema cannot be found in the internal storage, a schema hosted under
+  one of the supported URI schemes will be fetched and stored.
+  To maintain the old behavior (internal storage only) give the option
+  `schema_loader_fun` the value `fun jesse_database:load/1`.
+
 ## 1.4.0
 
 * Added jesse_error:to_json

--- a/src/jesse.erl
+++ b/src/jesse.erl
@@ -30,7 +30,7 @@
         , add_schema/3
         , del_schema/1
         , load_schemas/2
-        , load_schemas/4
+        , load_schemas/3
         , validate/2
         , validate/3
         , validate_with_schema/2
@@ -56,8 +56,7 @@ main(Args) ->
                     ok | jesse_error:error().
 add_schema(Key, Schema) ->
   ValidationFun = fun jesse_lib:is_json_object/1,
-  MakeKeyFun    = fun(_) -> Key end,
-  jesse_database:add(Schema, ValidationFun, MakeKeyFun).
+  jesse_database:add(Schema, ValidationFun, Key).
 
 %% @doc Equivalent to `add_schema/2', but `Schema' is a binary string, and
 %% the third agument is a parse function to convert the binary string to
@@ -84,10 +83,8 @@ del_schema(Key) ->
 
 %% @doc Loads schema definitions from filesystem to in-memory storage.
 %%
-%% Equivalent to `load_schemas(Path, ParserFun, ValidationFun, MakeKeyFun)'
-%% where `ValidationFun' is `fun jesse_json:is_json_object/1' and
-%% `MakeKeyFun' is `fun jesse_lib:get_schema_id/1'. In this case
-%% the key will be the value of `id' attribute from the given schemas.
+%% Equivalent to `load_schemas(Path, ParserFun, ValidationFun)'
+%% where `ValidationFun' is `fun jesse_json:is_json_object/1'.
 -spec load_schemas( Path      :: string()
                   , ParserFun :: fun((binary()) -> json_term())
                   ) -> jesse_database:update_result().
@@ -95,14 +92,12 @@ load_schemas(Path, ParserFun) ->
   load_schemas( Path
               , ParserFun
               , fun jesse_lib:is_json_object/1
-              , fun jesse_lib:get_schema_id/1
               ).
 
 %% @doc Loads schema definitions from filesystem to in-memory storage.
 %% The function loads all the files from directory `Path', then each schema
 %% entry will be checked for a validity by function `ValidationFun', and
-%% will be stored in in-memory storage with a key returned by `MakeKeyFun'
-%% function.
+%% will be stored in in-memory storage.
 %%
 %% In addition to a schema definition, a timestamp of the schema file will be
 %% stored, so, during the next update timestamps will be compared to avoid
@@ -117,10 +112,9 @@ load_schemas(Path, ParserFun) ->
 -spec load_schemas( Path          :: string()
                   , ParserFun     :: fun((binary()) -> json_term())
                   , ValidationFun :: fun((any()) -> boolean())
-                  , MakeKeyFun    :: fun((json_term()) -> any())
                   ) -> jesse_database:update_result().
-load_schemas(Path, ParserFun, ValidationFun, MakeKeyFun) ->
-  jesse_database:add_path(Path, ParserFun, ValidationFun, MakeKeyFun).
+load_schemas(Path, ParserFun, ValidationFun) ->
+  jesse_database:add_path(Path, ParserFun, ValidationFun).
 
 %% @doc Equivalent to {@link validate/3} where `Options' is an empty list.
 -spec validate( Schema :: any()

--- a/src/jesse.erl
+++ b/src/jesse.erl
@@ -120,7 +120,7 @@ load_schemas(Path, ParserFun) ->
                   , MakeKeyFun    :: fun((json_term()) -> any())
                   ) -> jesse_database:update_result().
 load_schemas(Path, ParserFun, ValidationFun, MakeKeyFun) ->
-  jesse_database:update(Path, ParserFun, ValidationFun, MakeKeyFun).
+  jesse_database:add_path(Path, ParserFun, ValidationFun, MakeKeyFun).
 
 %% @doc Equivalent to {@link validate/3} where `Options' is an empty list.
 -spec validate( Schema :: any()
@@ -149,7 +149,7 @@ validate(Schema, Data, Options) ->
   try
     ParserFun  = proplists:get_value(parser_fun, Options, fun(X) -> X end),
     ParsedData = try_parse(data, ParserFun, Data),
-    JsonSchema = jesse_database:read(Schema),
+    JsonSchema = jesse_database:load(Schema),
     jesse_schema_validator:validate(JsonSchema, ParsedData, Options)
   catch
     throw:Error -> {error, Error}

--- a/src/jesse_cli.erl
+++ b/src/jesse_cli.erl
@@ -106,38 +106,8 @@ jesse_run(JsonInstance, Schema) ->
   jesse:validate_with_schema( SchemaBinary
                             , JsonInstanceBinary
                             , [ {parser_fun, fun jsx:decode/1}
-                              , {schema_loader_fun, fun loader/1}
                               ]
                             ).
-loader(Id) ->
-  try
-    jesse_database:read(Id)
-  catch
-    throw:{database_error, Id, schema_not_found} ->
-      externalLoader(Id);
-    error:badarg -> % no ETS table ->
-      externalLoader(Id)
-  end.
-
-externalLoader("file://" ++ Path = URI) ->
-  {ok, Body} = file:read_file(Path),
-  ParsedSchema = jsx:decode(Body),
-  ok = jesse:add_schema(URI, ParsedSchema),
-  ParsedSchema;
-externalLoader("http://" ++ _ = URI) ->
-  {ok, Response} = httpc:request(get, {URI, []}, [], [{body_format, binary}]),
-  {{_Line, 200, _}, _Headers, Body} = Response,
-  ParsedSchema = jsx:decode(Body),
-  ok = jesse:add_schema(URI, ParsedSchema),
-  ParsedSchema;
-externalLoader("https://" ++ _ = URI) ->
-  {ok, Response} = httpc:request(get, {URI, []}, [], [{body_format, binary}]),
-  {{_Line, 200, _}, _Headers, Body} = Response,
-  ParsedSchema = jsx:decode(Body),
-  ok = jesse:add_schema(URI, ParsedSchema),
-  ParsedSchema;
-externalLoader(Id) ->
-  throw({database_error, Id, schema_not_found}).
 
 ensure_started(App) ->
   case application:start(App) of

--- a/src/jesse_cli.erl
+++ b/src/jesse_cli.erl
@@ -94,7 +94,7 @@ jesse_run(JsonInstance, Schema) ->
   {ok, SchemaBinary0} = file:read_file(Schema),
   SchemaJsx0 = jsx:decode(SchemaBinary0),
   SchemaFqdn = "file://" ++ filename:absname(Schema),
-  SchemaJsx = case proplists:get_value(<<"id">>, SchemaJsx0) of
+  SchemaJsx = case jesse_json_path:value(<<"id">>, SchemaJsx0, undefined) of
                 undefined ->
                   [ {<<"id">>, unicode:characters_to_binary(SchemaFqdn)}
                     | SchemaJsx0

--- a/src/jesse_database.erl
+++ b/src/jesse_database.erl
@@ -125,13 +125,13 @@ load(Key0) ->
   Table = create_table(table_name()),
   case ets:match_object(Table, {'_', Key, '_', '_'}) of
     %% ID
-    [{_SourceKey, Key, _TimeStamp, Schema}] ->
+    [{_SourceKey, Key, _Mtime, Schema}] ->
       Schema;
     [] ->
       SourceKey = Key,
       case ets:match_object(Table, {SourceKey, '_', '_', '_'}) of
         %% Source (URI)
-        [{SourceKey, _Key, _TimeStamp, Schema}] ->
+        [{SourceKey, _Key, _Mtime, Schema}] ->
           Schema;
         _ ->
           throw({database_error, Key, schema_not_found})

--- a/src/jesse_database.erl
+++ b/src/jesse_database.erl
@@ -292,8 +292,8 @@ get_schema_info(File, {Acc, ParseFun}) ->
 %% @private
 -spec get_schema_id(Schema :: jesse:json_term()) -> string() | undefined.
 get_schema_id(Schema) ->
-  case jesse_json_path:value(?ID, Schema, ?not_found) of
-    ?not_found ->
+  case jesse_json_path:value(?ID, Schema, undefined) of
+    undefined ->
       undefined;
     Id ->
       erlang:binary_to_list(Id)

--- a/src/jesse_database.erl
+++ b/src/jesse_database.erl
@@ -34,6 +34,7 @@
         , add_path/3
         , load/1
         , load_uri/1
+        , load_all/0
         , delete/1
         ]).
 
@@ -151,6 +152,12 @@ load_uri(Key) ->
       add_uri(Key),
       load(Key)
   end.
+
+%% @doc Loads all schemas in the internal storage.
+-spec load_all() -> [tuple()].
+load_all() ->
+  Table = create_table(table_name()),
+  ets:tab2list(Table).
 
 %% @doc Deletes a schema definition from the internal storage associated with,
 %% or sourced with the key `Key'.

--- a/src/jesse_database.erl
+++ b/src/jesse_database.erl
@@ -283,7 +283,15 @@ get_schema_infos(Files, ParseFun) ->
 get_schema_info(File, {Acc, ParseFun}) ->
   SourceKey = "file://" ++ filename:absname(File),
   {ok, SchemaBin} = file:read_file(File),
-  Schema = try_parse(ParseFun, SchemaBin),
+  Schema0 = try_parse(ParseFun, SchemaBin),
+  Schema = case jesse_json_path:value(<<"id">>, Schema0, undefined) of
+             undefined ->
+               [ {<<"id">>, unicode:characters_to_binary(SourceKey)}
+                 | Schema0
+               ];
+             _ ->
+               Schema0
+           end,
   {ok, #file_info{mtime = Mtime}} = file:read_file_info(File),
   {[{SourceKey, Mtime, Schema} | Acc], ParseFun}.
 

--- a/src/jesse_database.erl
+++ b/src/jesse_database.erl
@@ -30,153 +30,201 @@
 
 %% API
 -export([ add/3
-        , delete/1
-        , read/1
-        , update/4
+        , add_uri/1
+        , add_path/4
         , load/1
+        , load_uri/1
+        , delete/1
         ]).
 
--export_type([ update_result/0
-             , error/0
+-export_type([ error/0
+             , store_result/0
              ]).
 
--type update_result() :: ok | [fail()].
-
 -type error() :: {error, error_reason()}.
-
 -type error_reason() :: { 'database_error'
-                        , Key ::any()
-                        , 'schema_not_found'
+                        , Key :: string()
+                        , 'schema_not_found' | 'unknown_uri_scheme'
                         }.
 
--type fail()          :: {file:filename(), file:date_time(), reason()}.
--type reason()        :: term().
+-type store_result() :: ok | [store_fail()].
+-type store_fail()   :: {file:filename(), file:date_time(), reason()}.
+-type reason()       :: term().
 
 -define(JESSE_ETS, jesse_ets).
 
 -include_lib("kernel/include/file.hrl").
+-include("jesse_schema_validator.hrl").
 
 %%% API
-%% @doc Adds a schema definition `Schema' to in-memory storage associated with
-%% a key `Key'. It will overwrite an existing schema with the same key if
+%% @doc Adds a schema definition `Schema' to the internal storage associated
+%% with the key `Key'. It will overwrite an existing schema with the same key if
 %% there is any.
 -spec add( Schema        :: jesse:json_term()
          , ValidationFun :: fun((any()) -> boolean())
-         , MakeKeyFun    :: fun((jesse:json_term()) -> any())
-         ) -> update_result().
+         , MakeKeyFun    :: fun((jesse:json_term()) -> string())
+         ) -> store_result().
 add(Schema, ValidationFun, MakeKeyFun) ->
-  store_schema([{"", "", Schema}], ValidationFun, MakeKeyFun).
+  SchemaInfos = [{'$unknown', 0, Schema}],
+  store_schemas(SchemaInfos, ValidationFun, MakeKeyFun).
 
-%% @doc Deletes a schema definition from in-memory storage associated with
-%% the key `Key'.
--spec delete(Key :: any()) -> ok.
-delete(Key) ->
-  Table = table_name(),
-  ets:delete(Table, Key),
-  ok.
+%% @doc Add a schema definition to the internal storage identified by a URI Key.
+%% Supported URI schemes are file:, http: and https:. If this fails, an
+%% exception will be thrown.
+-spec add_uri(Key :: string()) -> store_result().
+add_uri("file://" ++ File = Key) ->
+  {ok, Body} = file:read_file(File),
+  {ok, #file_info{mtime = Mtime}} = file:read_file_info(File),
+  Schema = jsx:decode(Body),
+  SchemaInfos = [{Key, Mtime, Schema}],
+  ValidationFun = fun jesse_lib:is_json_object/1,
+  MakeKeyFun = fun get_schema_id/1,
+  store_schemas(SchemaInfos, ValidationFun, MakeKeyFun);
+add_uri("http://" ++ _ = Key) ->
+  {ok, Response} = httpc:request(get, {Key, []}, [], [{body_format, binary}]),
+  {{_Line, 200, _}, _Headers, Body} = Response,
+  Schema = jsx:decode(Body),
+  SchemaInfos = [{Key, 0, Schema}],
+  ValidationFun = fun jesse_lib:is_json_object/1,
+  MakeKeyFun = fun get_schema_id/1,
+  store_schemas(SchemaInfos, ValidationFun, MakeKeyFun);
+add_uri("https://" ++ _ = Key) ->
+  {ok, Response} = httpc:request(get, {Key, []}, [], [{body_format, binary}]),
+  {{_Line, 200, _}, _Headers, Body} = Response,
+  Schema = jsx:decode(Body),
+  SchemaInfos = [{Key, 0, Schema}],
+  ValidationFun = fun jesse_lib:is_json_object/1,
+  MakeKeyFun = fun get_schema_id/1,
+  store_schemas(SchemaInfos, ValidationFun, MakeKeyFun);
+add_uri(Key) ->
+  throw({database_error, Key, unknown_uri_scheme}).
 
-%% @doc Loads schema definitions from filesystem to in-memory storage.
-%% The function loads all the files from directory `Path', then each schema
-%% entry will be checked for a validity by function `ValidationFun', and
-%% will be stored in in-memory storage with a key returned by `MakeKeyFun'
-%% function.
+%% @doc Add schema definitions from all the files from directory `Dir', each
+%% being validated by `ValidationFun', and stored in the internal
+%% storage with a key returned by `MakeKeyFun'.
 %%
-%% In addition to a schema definition, a timestamp of the schema file will be
-%% stored, so, during the next update timestamps will be compared to avoid
-%% unnecessary updates.
+%% The file modification time will also be stored, to skip unnecessary updates.
 %%
-%% Schema definitions are stored in the format which json parsing function
-%% `ParseFun' returns.
+%% Schema definitions are stored in the format that `ParseFun' returns.
 %%
 %% NOTE: it's impossible to automatically update schema definitions added by
-%%       add_schema/2, the only way to update them is to use add_schema/2
-%%       again with the new definition.
--spec update( Path          :: string()
-            , ParseFun      :: fun((binary()) -> jesse:json_term())
-            , ValidationFun :: fun((any()) -> boolean())
-            , MakeKeyFun    :: fun((jesse:json_term()) -> any())
-            ) -> update_result().
-update(Path, ParseFun, ValidationFun, MakeKeyFun) ->
-  Schemas = load_schema(Path, get_updated_files(Path), ParseFun),
-  store_schema(Schemas, ValidationFun, MakeKeyFun).
+%%       add/2. The only way to update those is to use add/2 again with the new
+%%       definition.
+-spec add_path( Path          :: string()
+              , ParseFun      :: fun((binary()) -> jesse:json_term())
+              , ValidationFun :: fun((any()) -> boolean())
+              , MakeKeyFun    :: fun((jesse:json_term()) -> any())
+              ) -> store_result().
+add_path(Path0, ParseFun, ValidationFun, MakeKeyFun) ->
+  Path = jesse_state:canonical_path(Path0, "file:"),
+  SchemaInfos = get_schema_infos(list_outdated(Path), ParseFun),
+  store_schemas(SchemaInfos, ValidationFun, MakeKeyFun).
 
-%% @doc Reads a schema definition with the same key as `Key' from the internal
-%% storage. If there is no such key in the storage, an exception will be thrown.
--spec read(Key :: any()) -> jesse:json_term() | no_return().
-read(Key) ->
-  case ets:lookup(table_name(), Key) of
-    [{Key, _SecondaryKey, _TimeStamp, Term}] ->
-      Term;
-    _ ->
-      throw({database_error, Key, schema_not_found})
+%% @doc Loads a schema definition associated with, or sourced with the key `Key'
+%% from the internal storage. If there is no such key in the storage, an
+%% exception will be thrown.
+-spec load(Key :: string()) -> jesse:json_term() | no_return().
+load(Key0) ->
+  Key = jesse_state:canonical_path(Key0, Key0),
+  Table = create_table(table_name()),
+  case ets:match_object(Table, {Key, '_', '_', '_'}) of
+    [{Key, _SecondaryKey, _TimeStamp, Schema}] ->
+      Schema;
+    [] ->
+      SecondaryKey = Key,
+      case ets:match_object(Table, {'_', SecondaryKey, '_', '_'}) of
+        [{_Key, SecondaryKey, _TimeStamp, Schema}] ->
+          Schema;
+        _ ->
+          throw({database_error, Key, schema_not_found})
+      end
   end.
 
-%% @doc Reads a schema definition with the same key as `Key' from the internal
-%% storage. If there is no such key in the storage, it will try to fetch and add
-%% one to the internal storage if the Key uses the file:, http: or https: URI
-%% scheme. If this fails as well, an exception will be thrown.
--spec load(Key :: any()) -> jesse:json_term() | no_return().
-load(Key) ->
+%% @doc Loads a schema definition associated with, or sourced with the key `Key'
+%% from the internal storage. If there is no such key in the storage, it will
+%% try to fetch and add one to the internal storage if the Key uses the file:,
+%% http: or https: URI scheme. If this fails as well, an exception will be
+%% thrown.
+-spec load_uri(Key :: string()) -> jesse:json_term() | no_return().
+load_uri(Key) ->
   try
-    create_table(table_name()),
-    read(Key)
+    load(Key)
   catch
     throw:{database_error, Key, schema_not_found} ->
-      externalLoad(Key)
+      add_uri(Key),
+      load(Key)
   end.
 
+%% @doc Deletes a schema definition from the internal storage associated with,
+%% or sourced with the key `Key'.
+-spec delete(Key :: string()) -> ok.
+delete(Key0) ->
+  Key = jesse_state:canonical_path(Key0, Key0),
+  Table = create_table(table_name()),
+  ets:match_delete(Table, {Key, '_', '_', '_'}),
+  SecondaryKey = Key,
+  ets:match_delete(Table, {'_', SecondaryKey, '_', '_'}),
+  ok.
+
 %%% Internal functions
-%% @doc Stores schema definitions `Schemas' in in-memory storage.
-%% Uses `ValidationFun' to validate each schema definition before it is stored.
-%% Each schema definition is stored with a key returned by `MakeKeyFun' applied
-%% to the schema entry. Returns `ok' in case if all the schemas passed
-%% the validation and were stored, otherwise a list of invalid entries
-%% is returned.
-%% @private
-store_schema(Schemas, ValidationFun, MakeKeyFun) ->
-  Table    = create_table(table_name()),
-  StoreFun = fun({InFile, TimeStamp, Value} = Object, Acc) ->
-                 case ValidationFun(Value) of
-                   true ->
-                     NewObject = { MakeKeyFun(Value)
-                                 , InFile
-                                 , TimeStamp
-                                 , Value
-                                 },
-                     ets:insert(Table, NewObject),
-                     Acc;
-                   false ->
-                     [Object | Acc]
-                 end
-             end,
-  store_result(lists:foldl(StoreFun, [], Schemas)).
-
-%% @private
-store_result([])    -> ok;
-store_result(Fails) -> Fails.
-
 %% @doc Creates ETS table for internal cache if it does not exist yet,
 %% otherwise the name of the table is returned.
 %% @private
 create_table(TableName) ->
   case table_exists(TableName) of
-    false -> ets:new(TableName, [set, public, named_table]);
-    true -> TableName
-  end.
+    true ->
+      ok;
+    false ->
+      ets:new(TableName, [set, public, named_table])
+  end,
+  TableName.
 
 %% @doc Checks if ETS table with name `TableName' exists.
 %% @private
 table_exists(TableName) ->
-  case ets:info(TableName) of
-    undefined -> false;
-    _TableInfo -> true
+  ets:info(TableName) =/= undefined.
+
+%% @doc Stores information on schema definitions `SchemaInfos' in the internal
+%% storage. Uses `ValidationFun' to validate each schema definition before it
+%% is stored. Each schema definition is stored with a key returned by
+%% `MakeKeyFun' applied to the schema entry. Returns `ok' in case if all the
+%% schemas passed the validation and were stored, otherwise a list of invalid
+%% entries is returned.
+%% @private
+store_schemas(SchemaInfos, ValidationFun, MakeKeyFun) ->
+  {Fails, _, _} = lists:foldl( fun store_schema/2
+                             , {[], ValidationFun, MakeKeyFun}
+                             , SchemaInfos
+                             ),
+  case Fails of
+    [] ->
+      ok;
+    Fails ->
+      Fails
   end.
 
-%% @doc Returns a list of schema definitions files in `InDir' which need to be
-%% updated in the cache.
 %% @private
-get_updated_files(InDir) ->
-  case { get_file_list(InDir)
+store_schema(SchemaInfo, {Acc, ValidationFun, MakeKeyFun}) ->
+  {SourceKey, Mtime, Schema} = SchemaInfo,
+  case ValidationFun(Schema) of
+    true ->
+      Object = { MakeKeyFun(Schema)
+               , SourceKey
+               , Mtime
+               , Schema
+               },
+      Table = create_table(table_name()),
+      ets:insert(Table, Object),
+      {Acc, ValidationFun, MakeKeyFun};
+    false ->
+      {[SchemaInfo | Acc], ValidationFun, MakeKeyFun}
+  end.
+
+%% @doc Returns a list of schema files in `Path' which have outdated
+%% cache entries.
+%% @private
+list_outdated(Path) ->
+  case { list_dir(Path)
        , table_exists(table_name())
        } of
     {[] = Files, _TableExists} ->
@@ -184,32 +232,69 @@ get_updated_files(InDir) ->
     {Files, false} ->
       Files;
     {Files, _TableExists} ->
-      Filter = fun(InFile) ->
-                   is_outdated( get_full_path(InDir, InFile)
-                              , InFile
-                              )
-               end,
-      lists:filter(Filter, Files)
+      lists:filter(fun is_outdated/1, Files)
+  end.
+
+%% @private
+list_dir(Path0) ->
+  {ok, Listing} = file:list_dir(Path0),
+  lists:foldl( fun([], Acc) ->
+                   Acc;
+                  (Filename, Acc) ->
+                   Path = filename:join([Path0, Filename]),
+                   case filelib:is_dir(Path) of
+                     true ->
+                       [list_dir(Path) | Acc];
+                     false ->
+                       [Path | Acc]
+                   end
+               end
+             , []
+             ,  Listing
+             ).
+
+%% @doc Checks if a schema file `Filename' has an outdated cache entry.
+%% @private
+is_outdated(File) ->
+  SourceKey = "file://" ++ File,
+  case ets:match_object(table_name(), {'_', SourceKey, '_', '_'}) of
+    [] ->
+      true;
+    [{_Key, SourceKey, Mtime, _Schema}] ->
+      {ok, #file_info{mtime = CurrentMtime}} = file:read_file_info(File),
+      CurrentMtime > Mtime
   end.
 
 %% @doc Loads schema definitions from a list of files `Files' located in
-%% directory `InDir', and parses each of entry by the given parse
+%% directory `Path', and parses each of entry by the given parse
 %% function `ParseFun'. Silently ignores subdirectories.
 %% @private
-load_schema(InDir, Files, ParseFun) ->
-  LoadFun = fun(InFile, Acc) ->
-                InFilePath      = get_full_path(InDir, InFile),
-                case file:read_file(InFilePath) of
-                  {ok, SchemaBin} ->
-                    {ok, FileInfo}  = file:read_file_info(InFilePath),
-                    TimeStamp       = FileInfo#file_info.mtime,
-                    Schema          = try_parse(ParseFun, SchemaBin),
-                    [{InFile, TimeStamp, Schema} | Acc];
-                  {error, eisdir} ->
-                    Acc
-                end
-            end,
-  lists:foldl(LoadFun, [], Files).
+get_schema_infos(Files, ParseFun) ->
+  {SchemaInfos, ParseFun} = lists:foldl( fun get_schema_info/2
+                                       , {[], ParseFun}
+                                       , Files
+                                       ),
+  SchemaInfos.
+
+%% @private
+get_schema_info(File, {Acc, ParseFun}) ->
+  SourceKey = "file://" ++ File,
+  {ok, SchemaBin} = file:read_file(File),
+  Schema = try_parse(ParseFun, SchemaBin),
+  {ok, #file_info{mtime = Mtime}} = file:read_file_info(File),
+  {[{SourceKey, Mtime, Schema} | Acc], ParseFun}.
+
+%% @doc Returns value of "id" field from json object `Schema', assuming that
+%% the given json object has such a field, otherwise return '$unknown'.
+%% @private
+-spec get_schema_id(Schema :: jesse:json_term()) -> string() | '$unknown'.
+get_schema_id(Schema) ->
+  case jesse_json_path:value(?ID, Schema, ?not_found) of
+    ?not_found ->
+      '$unknown';
+    Id ->
+      erlang:binary_to_list(Id)
+  end.
 
 %% @doc Wraps up calls to a third party json parser.
 %% @private
@@ -221,60 +306,9 @@ try_parse(ParseFun, SchemaBin) ->
       {parse_error, Error}
   end.
 
-%% @private
-get_file_list(InDir) ->
-  {ok, Files} = file:list_dir(InDir),
-  Files.
-
-%% @private
-get_full_path(Dir, File) ->
-  filename:join([Dir, File]).
-
-%% @doc Checks if a cache entry for a schema definition from file `InFile'
-%% is outdated. Returns `true' if the cache entry needs to be updated, or if
-%% the entry does not exist in the cache, otherwise `false' is returned.
-%% @private
-is_outdated(InFile, SecondaryKey) ->
-  case ets:match_object(table_name(), {'_', SecondaryKey, '_', '_'}) of
-    [] ->
-      true;
-    [{_Key, SecondaryKey, TimeStamp, _Value}] ->
-      {ok, #file_info{mtime = MtimeIn}} = file:read_file_info(InFile),
-      MtimeIn > TimeStamp
-  end.
-
-%% @doc Returns a name of ETS table which is used for in-memory cache.
+%% @doc Returns a name of ETS table which is used for the internal cache.
 %% Could be rewritten to use a configuration parameter instead of a hardcoded
 %% value.
 %% @private
-table_name() -> ?JESSE_ETS.
-
-%% @doc Try to fetch and add a schema definition to the internal storage if
-%% the Key uses the file:, http: or https: URI scheme. If this fails, an
-%% exception will be thrown.
--spec externalLoad(Key :: any()) -> jesse:json_term() | no_return().
-externalLoad("file://" ++ Path = Key) ->
-  {ok, Body} = file:read_file(Path),
-  Schema = jsx:decode(Body),
-  ValidationFun = fun jesse_lib:is_json_object/1,
-  MakeKeyFun    = fun(_) -> Key end,
-  ok = jesse_database:add(Schema, ValidationFun, MakeKeyFun),
-  Schema;
-externalLoad("http://" ++ _ = Key) ->
-  {ok, Response} = httpc:request(get, {Key, []}, [], [{body_format, binary}]),
-  {{_Line, 200, _}, _Headers, Body} = Response,
-  Schema = jsx:decode(Body),
-  ValidationFun = fun jesse_lib:is_json_object/1,
-  MakeKeyFun    = fun(_) -> Key end,
-  ok = jesse_database:add(Schema, ValidationFun, MakeKeyFun),
-  Schema;
-externalLoad("https://" ++ _ = Key) ->
-  {ok, Response} = httpc:request(get, {Key, []}, [], [{body_format, binary}]),
-  {{_Line, 200, _}, _Headers, Body} = Response,
-  Schema = jsx:decode(Body),
-  ValidationFun = fun jesse_lib:is_json_object/1,
-  MakeKeyFun    = fun(_) -> Key end,
-  ok = jesse_database:add(Schema, ValidationFun, MakeKeyFun),
-  Schema;
-externalLoad(Key) ->
-  throw({database_error, Key, schema_not_found}).
+table_name() ->
+  ?JESSE_ETS.

--- a/src/jesse_lib.erl
+++ b/src/jesse_lib.erl
@@ -25,7 +25,6 @@
 
 %% API
 -export([ empty_if_not_found/1
-        , get_schema_id/1
         , is_array/1
         , is_json_object/1
         , is_null/1
@@ -39,16 +38,6 @@
 -spec empty_if_not_found(Value :: any()) -> any().
 empty_if_not_found(?not_found) -> [];
 empty_if_not_found(Value)      -> Value.
-
-%% @doc Returns value of "id" field from json object `Schema', assuming that
-%% the given json object has such a field, otherwise an exception
-%% will be thrown.
--spec get_schema_id(Schema :: jesse:json_term()) -> string().
-get_schema_id(Schema) ->
-  case jesse_json_path:value(?ID, Schema, ?not_found) of
-    ?not_found -> throw({schema_invalid, Schema, missing_id_field});
-    Id         -> erlang:binary_to_list(Id)
-  end.
 
 %% @doc Checks if the given value is json `array'.
 %% This check is needed since objects in `jsx' are lists (proplists).

--- a/src/jesse_schema_validator.hrl
+++ b/src/jesse_schema_validator.hrl
@@ -70,7 +70,7 @@
 -define(json_schema_draft3, <<"http://json-schema.org/draft-03/schema#">>).
 -define(json_schema_draft4, <<"http://json-schema.org/draft-04/schema#">>).
 -define(default_schema_ver, ?json_schema_draft3).
--define(default_schema_loader_fun, fun jesse_database:load/1).
+-define(default_schema_loader_fun, fun jesse_database:load_uri/1).
 -define(default_error_handler_fun, fun jesse_error:default_error_handler/3).
 
 %% Constant definitions for schema errors

--- a/src/jesse_schema_validator.hrl
+++ b/src/jesse_schema_validator.hrl
@@ -70,7 +70,7 @@
 -define(json_schema_draft3, <<"http://json-schema.org/draft-03/schema#">>).
 -define(json_schema_draft4, <<"http://json-schema.org/draft-04/schema#">>).
 -define(default_schema_ver, ?json_schema_draft3).
--define(default_schema_loader_fun, fun jesse_database:read/1).
+-define(default_schema_loader_fun, fun jesse_database:load/1).
 -define(default_error_handler_fun, fun jesse_error:default_error_handler/3).
 
 %% Constant definitions for schema errors


### PR DESCRIPTION
I wanted to address only #23 at first, but when cleaning up, I involuntarily ended up tackling the todos in https://github.com/for-GET/jesse/issues/13#issuecomment-190431727

In short, this messy PR (due to the commit history and lack of new tests)
- loads schemas on demand (the initial validation schema needs an `id` though) within the file/http/https schemes
- uses fully-qualified keys for the schemas, meaning these are equivalent "./test1.json", "test1.json", "foo/../test1.json", etc
- schemas are stored internally as
  - `SourceKey` e.g. file://path/file.json
  - `Key` the schema's `id`
  - Modified time
  - Schema
- the CLI version is now working closer to the expectations (loading schemas from the filesystem on demand)
