### PR TITLE
- use the unicode option for re:run() when filtering the extra names

### DIFF
--- a/src/jesse_validator_draft3.erl
+++ b/src/jesse_validator_draft3.erl
@@ -487,7 +487,7 @@ get_additional_properties(Value, Properties, PatternProperties) ->
 %% @private
 filter_extra_names(Pattern, ExtraNames) ->
   Filter = fun(ExtraName) ->
-               case re:run(ExtraName, Pattern, [{capture, none}]) of
+               case re:run(ExtraName, Pattern, [{capture, none}, unicode]) of
                  match   -> false;
                  nomatch -> true
                end

--- a/src/jesse_validator_draft4.erl
+++ b/src/jesse_validator_draft4.erl
@@ -490,7 +490,7 @@ get_additional_properties(Value, Properties, PatternProperties) ->
 %% @private
 filter_extra_names(Pattern, ExtraNames) ->
   Filter = fun(ExtraName) ->
-               case re:run(ExtraName, Pattern, [{capture, none}]) of
+               case re:run(ExtraName, Pattern, [{capture, none}, unicode]) of
                  match   -> false;
                  nomatch -> true
                end


### PR DESCRIPTION
Currently the validation rejects patterns with unicode names if the additional properties are false. To be able to verify those correctly we have to add the unicode option to the re:run when filtering out the names.