### PR TITLE
Implement standard formats for draft-04 validation

### DIFF
--- a/src/jesse_validator_draft4.erl
+++ b/src/jesse_validator_draft4.erl
@@ -963,6 +963,11 @@ check_format(Value, _Format = <<"time">>, State) when is_binary(Value) ->
     true  -> State;
     false -> handle_data_invalid(?wrong_format, Value, State)
   end;
+check_format(Value, _Format = <<"email">>, State) when is_binary(Value) ->
+  case re:run(Value, <<"^[^@]+@[^@]+$">>, [{capture, none}, unicode]) of
+    match   -> State;
+    nomatch -> handle_data_invalid(?wrong_format, Value, State)
+  end;
 check_format(Value, _Format = <<"ip-address">>, State) when is_binary(Value) ->
   case inet:parse_ipv4strict_address(binary_to_list(Value)) of
     {ok, _IPv4Address} -> State;

--- a/src/jesse_validator_draft4.erl
+++ b/src/jesse_validator_draft4.erl
@@ -944,7 +944,6 @@ check_enum(Value, Enum, State) ->
 
 %% @doc format
 %% Used for semantic validation.
-%% TODO: Implement the standard formats
 %% @private
 check_format(Value, _Format = <<"date">>, State) when is_binary(Value) ->
   case valid_date(Value) of

--- a/src/jesse_validator_draft4.erl
+++ b/src/jesse_validator_draft4.erl
@@ -951,6 +951,11 @@ check_format(Value, _Format = <<"date">>, State) when is_binary(Value) ->
     true  -> State;
     false -> handle_data_invalid(?wrong_format, Value, State)
   end;
+check_format(Value, _Format = <<"time">>, State) when is_binary(Value) ->
+  case valid_time(Value) of
+    true  -> State;
+    false -> handle_data_invalid(?wrong_format, Value, State)
+  end;
 check_format(_Value, _Format, State) ->
   State.
 
@@ -1317,3 +1322,21 @@ valid_date(<<Year:4/bytes, $-, Month:2/bytes, $-, Day:2/bytes>>) ->
     error:badarg -> false
   end;
 valid_date(_Other) -> false.
+
+%% @private
+valid_time(<<Hour:2/bytes, $:, Minute:2/bytes, $:, Second:2/bytes>>) ->
+  try { binary_to_integer(Hour)
+      , binary_to_integer(Minute)
+      , binary_to_integer(Second)
+      }
+  of
+      {H, M, S} when
+        H >= 0, H =< 23,
+        M >= 0, M =< 59,
+        S >= 0, S =< 50;
+        H =:= 24, M =:= 0, S =:= 0 -> true;
+      _Other -> false
+  catch
+    error:badarg -> false
+  end;
+valid_time(_Other) -> false.

--- a/src/jesse_validator_draft4.erl
+++ b/src/jesse_validator_draft4.erl
@@ -968,6 +968,11 @@ check_format(Value, _Format = <<"ip-address">>, State) when is_binary(Value) ->
     {ok, _IPv4Address} -> State;
     {error, einval}    -> handle_data_invalid(?wrong_format, Value, State)
   end;
+check_format(Value, _Format = <<"ipv6">>, State) when is_binary(Value) ->
+  case inet:parse_ipv6strict_address(binary_to_list(Value)) of
+    {ok, _IPv6Address} -> State;
+    {error, einval}    -> handle_data_invalid(?wrong_format, Value, State)
+  end;
 check_format(_Value, _Format, State) ->
   State.
 

--- a/src/jesse_validator_draft4.erl
+++ b/src/jesse_validator_draft4.erl
@@ -963,6 +963,11 @@ check_format(Value, _Format = <<"time">>, State) when is_binary(Value) ->
     true  -> State;
     false -> handle_data_invalid(?wrong_format, Value, State)
   end;
+check_format(Value, _Format = <<"ip-address">>, State) when is_binary(Value) ->
+  case inet:parse_ipv4strict_address(binary_to_list(Value)) of
+    {ok, _IPv4Address} -> State;
+    {error, einval}    -> handle_data_invalid(?wrong_format, Value, State)
+  end;
 check_format(_Value, _Format, State) ->
   State.
 

--- a/src/jesse_validator_draft4.erl
+++ b/src/jesse_validator_draft4.erl
@@ -1335,9 +1335,9 @@ remove_last_from_path(State) ->
 %% @private
 valid_date(<<Year:4/bytes, $-, Month:2/bytes, $-, Day:2/bytes>>) ->
   try
-    calendar:valid_date( binary_to_integer(Year)
-                       , binary_to_integer(Month)
-                       , binary_to_integer(Day)
+    calendar:valid_date( list_to_integer(binary_to_list(Year))
+                       , list_to_integer(binary_to_list(Month))
+                       , list_to_integer(binary_to_list(Day))
                        )
   catch
     error:badarg -> false
@@ -1346,9 +1346,9 @@ valid_date(_Other) -> false.
 
 %% @private
 valid_time(<<Hour:2/bytes, $:, Minute:2/bytes, $:, Second:2/bytes>>) ->
-  try { binary_to_integer(Hour)
-      , binary_to_integer(Minute)
-      , binary_to_integer(Second)
+  try { list_to_integer(binary_to_list(Hour))
+      , list_to_integer(binary_to_list(Minute))
+      , list_to_integer(binary_to_list(Second))
       }
   of
       {H, M, S} when

--- a/src/jesse_validator_draft4.erl
+++ b/src/jesse_validator_draft4.erl
@@ -968,12 +968,12 @@ check_format(Value, _Format = <<"email">>, State) when is_binary(Value) ->
     nomatch -> handle_data_invalid(?wrong_format, Value, State)
   end;
 check_format(Value, _Format = <<"ip-address">>, State) when is_binary(Value) ->
-  case inet:parse_ipv4strict_address(binary_to_list(Value)) of
+  case inet_parse:ipv4strict_address(binary_to_list(Value)) of
     {ok, _IPv4Address} -> State;
     {error, einval}    -> handle_data_invalid(?wrong_format, Value, State)
   end;
 check_format(Value, _Format = <<"ipv6">>, State) when is_binary(Value) ->
-  case inet:parse_ipv6strict_address(binary_to_list(Value)) of
+  case inet_parse:ipv6strict_address(binary_to_list(Value)) of
     {ok, _IPv6Address} -> State;
     {error, einval}    -> handle_data_invalid(?wrong_format, Value, State)
   end;

--- a/src/jesse_validator_draft4.erl
+++ b/src/jesse_validator_draft4.erl
@@ -946,6 +946,11 @@ check_enum(Value, Enum, State) ->
 %% Used for semantic validation.
 %% TODO: Implement the standard formats
 %% @private
+check_format(Value, _Format = <<"date">>, State) when is_binary(Value) ->
+  case valid_date(Value) of
+    true  -> State;
+    false -> handle_data_invalid(?wrong_format, Value, State)
+  end;
 check_format(_Value, _Format, State) ->
   State.
 
@@ -1300,3 +1305,15 @@ add_to_path(State, Property) ->
 %% @private
 remove_last_from_path(State) ->
   jesse_state:remove_last_from_path(State).
+
+%% @private
+valid_date(<<Year:4/bytes, $-, Month:2/bytes, $-, Day:2/bytes>>) ->
+  try
+    calendar:valid_date( binary_to_integer(Year)
+                       , binary_to_integer(Month)
+                       , binary_to_integer(Day)
+                       )
+  catch
+    error:badarg -> false
+  end;
+valid_date(_Other) -> false.

--- a/src/jesse_validator_draft4.erl
+++ b/src/jesse_validator_draft4.erl
@@ -951,6 +951,13 @@ check_format(Value, _Format = <<"date">>, State) when is_binary(Value) ->
     true  -> State;
     false -> handle_data_invalid(?wrong_format, Value, State)
   end;
+check_format(Value, _Format = <<"date-time">>, State) when is_binary(Value) ->
+  try
+    <<Date:10/bytes, $T, Time:8/bytes, $Z>> = Value,
+    valid_date(Date) andalso valid_time(Time)
+  catch
+    error:{badmatch, _} -> handle_data_invalid(?wrong_format, Value, State)
+  end;
 check_format(Value, _Format = <<"time">>, State) when is_binary(Value) ->
   case valid_time(Value) of
     true  -> State;


### PR DESCRIPTION
Is there are reason standard formats aren't implemented in `jesse`?