### PR TITLE
fix error list for inner validations

### DIFF
--- a/src/jesse_validator_draft3.erl
+++ b/src/jesse_validator_draft3.erl
@@ -208,11 +208,9 @@ check_value(Value, [{?DISALLOW, Disallow} | Attrs], State) ->
 check_value(Value, [{?EXTENDS, Extends} | Attrs], State) ->
   NewState = check_extends(Value, Extends, State),
   check_value(Value, Attrs, NewState);
-check_value(Value, [{?REF, RefSchemaURI}], State) ->
-  {NewState0, Schema} = resolve_ref(RefSchemaURI, State),
-  NewState =
-    jesse_schema_validator:validate_with_state(Schema, Value, NewState0),
-  undo_resolve_ref(NewState, State);
+check_value(Value, [{?REF, RefSchemaURI} | Attrs], State) ->
+  NewState = resolve_ref(Value, RefSchemaURI, State),
+  check_value(Value, Attrs, NewState);
 check_value(_Value, [], State) ->
   State;
 check_value(Value, [_Attr | Attrs], State) ->
@@ -899,13 +897,12 @@ check_extends_array(Value, Extends, State) ->
              ).
 
 %% @private
-resolve_ref(Reference, State) ->
+resolve_ref(Value, Reference, State) ->
   NewState = jesse_state:resolve_ref(State, Reference),
   Schema = get_current_schema(NewState),
-  {NewState, Schema}.
-
-undo_resolve_ref(State, OriginalState) ->
-  jesse_state:undo_resolve_ref(State, OriginalState).
+  ResultState = jesse_schema_validator:validate_with_state(Schema, Value, NewState),
+  ErrorList = jesse_state:get_error_list(State) ++ jesse_state:get_error_list(ResultState),
+  jesse_state:set_error_list(State, ErrorList).
 
 %%=============================================================================
 %% @doc Returns `true' if given values (instance) are equal, otherwise `false'


### PR DESCRIPTION
this pr solves 3 issues.

. allow mixing draft3/4 versions in validation
. error list reset in draft4 all_of, any_of, one_of
. report missing required property