### PR TITLE
Load schemas passed to jesse CLI into jesse database

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,15 @@ Please keep in mind that the public API is the `jesse.erl` module alone.
 
 You can fire up `jesse` from the CLI, with
 ```bash
-bin/jesse path_to_json_schema -- path_to_json_instance [path_to_json_instance]
+bin/jesse [path_to_json_schema] path_to_json_schema -- path_to_json_instance [path_to_json_instance]
 ```
 
 You can also output the result in JSON format, with `--json`, and beautify it e.g. with python
 ```bash
-bin/jesse path_to_json_schema --json -- path_to_json_instance [path_to_json_instance] | python -m json.tool
+bin/jesse [path_to_json_schema] path_to_json_schema --json -- path_to_json_instance [path_to_json_instance] | python -m json.tool
 ```
+
+You can pass multiple JSON schemas which should be loaded into jesse in-memory storage, but JSON instances will be validated against the last JSON schema passed.
 
 ## Quick start - Erlang
 


### PR DESCRIPTION
**Problem:**
You cannot use `jesse` CLI for validation of schemas that use references (whether internal or external).

**Solution:**
- Load schemas to `jesse` database for JSON schema validation in `jesse` CLI.
- Allow multiple schemas to be passed (and loaded) into `jesse` database to enable schemas spanning multiple files (think references).
- The last schema passed will be used for actual validation - backwards compatible with the previous CLI syntax.