### PR TITLE
Fix recursive directory listing in jesse database

### DIFF
--- a/src/jesse_database.erl
+++ b/src/jesse_database.erl
@@ -233,7 +233,7 @@ list_dir(Path0) ->
                    Path = filename:join([Path0, Filename]),
                    case filelib:is_dir(Path) of
                      true ->
-                       [list_dir(Path) | Acc];
+                       list_dir(Path) ++ Acc;
                      false ->
                        [Path | Acc]
                    end

--- a/src/jesse_database.erl
+++ b/src/jesse_database.erl
@@ -224,23 +224,15 @@ list_outdated(Path) ->
       lists:filter(fun is_outdated/1, Files)
   end.
 
+%% @doc Recursively lists all regular files from a directory `Dir`.
 %% @private
-list_dir(Path0) ->
-  {ok, Listing} = file:list_dir(Path0),
-  lists:foldl( fun([], Acc) ->
-                   Acc;
-                  (Filename, Acc) ->
-                   Path = filename:join([Path0, Filename]),
-                   case filelib:is_dir(Path) of
-                     true ->
-                       list_dir(Path) ++ Acc;
-                     false ->
-                       [Path | Acc]
-                   end
-               end
-             , []
-             ,  Listing
-             ).
+list_dir(Dir) ->
+  filelib:fold_files( Dir
+                    , "^.*$" %% Allow any regular file.
+                    , true
+                    , fun(Path, Acc) -> [Path | Acc] end
+                    , []
+                    ).
 
 %% @doc Checks if a schema file `Filename' has an outdated cache entry.
 %% @private


### PR DESCRIPTION
**Problem:**
`jesse_database:list_dir/1` is broken - while recursively listing files in directory it produces a nested list of filenames i.e.
```Erlang
[[[],"first/second/third.json", "first/second/fourth.json"]]
```
instead of
```Erlang
["first/second/third.json", "first/second/fourth.json"]
```

This produces a cryptic error message when trying to use `jesse:load_schemas/2,3` or `jesse_database:add_path/3`:
```Erlang
** exception error: no match of right hand side value {error,enoent}
     in function  jesse_database:get_schema_info/2 (src/jesse_database.erl, line 272)
     in call from lists:foldl/3 (lists.erl, line 1263)
     in call from jesse_database:get_schema_infos/2 (src/jesse_database.erl, line 262)
     in call from jesse_database:add_path/3 (src/jesse_database.erl, line 102)
```

**Solution:**
Make `jesse_database:list_dir/1` always produce a flat list of files within directory, appending any subdirectory listings.