### PR TITLE
Fix jesse_state #state.id type

### DIFF
--- a/src/jesse_state.erl
+++ b/src/jesse_state.erl
@@ -68,7 +68,7 @@
                                           jesse:json_term() |
                                           ?not_found
                                             )
-         , id                 :: binary() | 'undefined'
+         , id                 :: http_uri:uri() | 'undefined'
          }
        ).
 


### PR DESCRIPTION
**Problem:**
https://travis-ci.org/for-GET/jesse/jobs/210159241
https://github.com/for-GET/jesse/commit/84a6e93198fa437d8a2965d7e3c6a6f83b9ffc32#diff-70cc40937373cde9cea9266b655884c0R191
These changes revealed that `jesse_state`'s #state.id was misspecified.

**Solution:**
🎆 🍾 