### PR TITLE
Add missing application dependencies for rebar3 relx-based release

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -44,4 +44,5 @@
                     , kernel
                     , stdlib
                     , jsx
+                    , rfc3339
                     ]}.

--- a/src/jesse.app.src
+++ b/src/jesse.app.src
@@ -5,6 +5,8 @@
                       , {registered, []}
                       , {applications, [ kernel
                                        , stdlib
+                                       , jsx
+                                       , rfc3339
                                        ]}
                       , {maintainers, [ "for-GET/jesse"
                                       ]}

--- a/src/jesse_cli.erl
+++ b/src/jesse_cli.erl
@@ -89,6 +89,7 @@ jesse_run(JsonInstance, Schema, Schemata) ->
   %% nor application:ensure_started(_)
   %% in order to maintain compatibility with R16B01 and lower
   ok = ensure_started(jsx),
+  ok = ensure_started(rfc3339),
   ok = ensure_started(jesse),
   ok = add_schemata(Schemata),
   {ok, JsonInstanceBinary} = file:read_file(JsonInstance),


### PR DESCRIPTION
**Problem:**
When generating a release using `relx` via `rebar3`, `rfc3339` isn't included in the release package.

**Solution:**
Add all dependencies into `applications` section of `jesse.app.src`