### PR TITLE
A bit different approach to external validators plus validation against definition in a schema 

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,3 +15,4 @@ Andrei Neculau <andrei.neculau@gmail.com>
 Stefan Strigler <stefan@strigler.de>
 Sergey Prokhorov <root@seriyps.ru>
 Yakov <xazar.studio@gmail.com>
+Anton Belyaev <xantbel@gmail.com>

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ eunit:
 
 .PHONY: ct
 ct:
-	$(REBAR) ct skip_deps=true suites="jesse_tests_draft3,jesse_tests_draft4"
+	$(REBAR) ct skip_deps=true suites="jesse_tests_draft3,jesse_tests_draft4,jesse_tests_generic"
 
 .PHONY: xref
 xref:

--- a/README.md
+++ b/README.md
@@ -128,6 +128,38 @@ ok
                       [<<"foo">>]}]}
 ```
 
+* Validate an instanse against a particular definition from schema definitions
+
+```erlang
+1> Schema = <<"{\"definitions\": {\"Foo\": {\"properties\": {\"foo\": {\"type\": \"integer\"}}}, \"Bar\": {\"properties\": {\"bar\": {\"type\": \"boolean\"}}}}}">>.
+<<"{\"definitions\": {\"Foo\": {\"properties\": {\"foo\": {\"type\": \"integer\"}}}, \"Bar\": {\"properties\": {\"bar\": {\"type\": \"boolea"...>>
+2> jesse:validate_definition("Foo",
+2>                            Schema,
+2>                            <<"{\"foo\": 1}">>,
+2>                            [{parser_fun, fun jiffy:decode/1}]).
+{ok,[{<<"foo">>,1}]}
+3> jesse:validate_definition("Bar",
+3>                            Schema,
+3>                            <<"{\"bar\": 2}">>,
+3>                            [{parser_fun, fun jiffy:decode/1}]).
+{error,[{data_invalid,[{<<"type">>,<<"boolean">>}],
+                      wrong_type,2,
+                      [<<"bar">>]}]}
+4> jesse:validate_definition("FooBar",
+4>                            Schema,
+4>                            <<"{\"bar\": 2}">>,
+4>                            [{parser_fun, fun jiffy:decode/1}]).
+{error,[{schema_invalid,[{<<"definitions">>,
+                          [{<<"Foo">>,
+                            [{<<"properties">>,
+                              [{<<"foo">>,[{<<"type">>,<<"integer">>}]}]}]},
+                           {<<"Bar">>,
+                            [{<<"properties">>,
+                              [{<<"bar">>,[{<<"type">>,<<"boolean">>}]}]}]}]}],
+                        {schema_not_found,"#/definitions/FooBar"}}]}
+```
+
+
 * Since 0.4.0 it's possible to instruct jesse to collect errors, and not stop
   immediately when it finds an error in the given JSON instance:
 
@@ -244,6 +276,11 @@ the given schema), one should use 'default_schema_ver' option when call
 `jesse:validate/3` or `jesse:validate_with_schema/3`, the value should be
 a binary consisting a schema path,
  i.e. <<"http://json-schema.org/draft-03/schema#">>.
+
+It is also possible to specify a validator module to use via `validator` option.
+This option supersedes the mechanism with the $schema property described above.
+Custom validator module can be specified as well. Such module should implement
+`jesse_schema_validator` behaviour.
 
 ## Validation errors
 

--- a/src/jesse.erl
+++ b/src/jesse.erl
@@ -33,6 +33,8 @@
         , load_schemas/3
         , validate/2
         , validate/3
+        , validate_ref/2
+        , validate_ref/3
         , validate_with_schema/2
         , validate_with_schema/3
         ]).
@@ -150,6 +152,34 @@ validate(Schema, Data, Options) ->
     throw:Error -> {error, Error}
   end.
 
+%% @doc Equivalent to {@link validate/2} where `Ref' is an absolute $ref
+%% which base Uri is a schema key in the internal storage.
+-spec validate_ref( Ref  :: string()
+                  , Data :: json_term() | binary()
+                  ) -> {ok, json_term()}
+                 | jesse_error:error()
+                 | jesse_database:error().
+validate_ref(Ref, Data) ->
+  validate_ref(Ref, Data, []).
+
+%% @doc Equivalent to {@link validate/3} where `Ref' is an absolute $ref
+%% which base Uri is a schema key in the internal storage.
+-spec validate_ref( Ref     :: string()
+                  , Data    :: json_term() | binary()
+                  , Options :: [{Key :: atom(), Data :: any()}]
+                  ) -> {ok, json_term()}
+                 | jesse_error:error()
+                 | jesse_database:error().
+validate_ref(Ref, Data, Options) ->
+  try
+    ParserFun  = proplists:get_value(parser_fun, Options, fun(X) -> X end),
+    ParsedData = try_parse(data, ParserFun, Data),
+    {JsonSchema, LocalRef} = parse_ref(Ref),
+    jesse_schema_validator:validate_ref(LocalRef, JsonSchema, ParsedData, Options)
+  catch
+    throw:Error -> {error, Error}
+  end.
+
 %% @doc Equivalent to {@link validate_with_schema/3} where `Options'
 %% is an empty list.
 -spec validate_with_schema( Schema :: json_term() | binary()
@@ -195,3 +225,15 @@ try_parse(Type, ParserFun, JsonBin) ->
         schema -> throw({schema_error, {parse_error, Error}})
       end
   end.
+
+%% @doc Loads schema from the internal storage according to the base uri
+%% in `Ref' and prepares local ref.
+%% @private
+parse_ref(Ref) ->
+  [BaseURI, LocalRef] = re:split( Ref
+                                , <<$#>>
+                                , [{return, binary}, unicode]
+                                ),
+  JsonSchema = jesse_database:load(binary_to_list(BaseURI)),
+  LocalRef1  = <<$#, LocalRef/binary>>,
+  {JsonSchema, LocalRef1}.

--- a/src/jesse_schema_validator.erl
+++ b/src/jesse_schema_validator.erl
@@ -25,6 +25,7 @@
 
 %% API
 -export([ validate/3
+        , validate_ref/4
         , validate_with_state/3
         ]).
 
@@ -53,6 +54,21 @@
 validate(JsonSchema, Value, Options) ->
   State    = jesse_state:new(JsonSchema, Options),
   NewState = validate_with_state(JsonSchema, Value, State),
+  {result(NewState), Value}.
+
+%% @doc Validates json `Data' against `Ref' in `JsonSchema' with `Options'.
+%% If the given json is valid, then it is returned to the caller as is,
+%% otherwise an exception will be thrown.
+-spec validate_ref( Ref        :: binary()
+                  , JsonSchema :: jesse:json_term()
+                  , Data       :: jesse:json_term()
+                  , Options    :: [{Key :: atom(), Data :: any()}]
+                  ) -> {ok, jesse:json_term()}
+                     | no_return().
+validate_ref(Ref, JsonSchema, Value, Options) ->
+  State    = jesse_state:new(JsonSchema, Options),
+  Schema   = [{<<"$ref">>, Ref}],
+  NewState = validate_with_state(Schema, Value, State),
   {result(NewState), Value}.
 
 %% @doc Validates json `Data' against `JsonSchema' with `State'.

--- a/src/jesse_schema_validator.erl
+++ b/src/jesse_schema_validator.erl
@@ -25,7 +25,7 @@
 
 %% API
 -export([ validate/3
-        , validate_ref/4
+        , validate_definition/4
         , validate_with_state/3
         ]).
 
@@ -56,18 +56,18 @@ validate(JsonSchema, Value, Options) ->
   NewState = validate_with_state(JsonSchema, Value, State),
   {result(NewState), Value}.
 
-%% @doc Validates json `Data' against `Ref' in `JsonSchema' with `Options'.
+%% @doc Validates json `Data' against `Definition' in `JsonSchema' with `Options'.
 %% If the given json is valid, then it is returned to the caller as is,
 %% otherwise an exception will be thrown.
--spec validate_ref( Ref        :: binary()
-                  , JsonSchema :: jesse:json_term()
-                  , Data       :: jesse:json_term()
-                  , Options    :: [{Key :: atom(), Data :: any()}]
-                  ) -> {ok, jesse:json_term()}
-                     | no_return().
-validate_ref(Ref, JsonSchema, Value, Options) ->
+-spec validate_definition( Definition :: string()
+                         , JsonSchema :: jesse:json_term()
+                         , Data       :: jesse:json_term()
+                         , Options    :: [{Key :: atom(), Data :: any()}]
+                         ) -> {ok, jesse:json_term()}
+                            | no_return().
+validate_definition(Defintion, JsonSchema, Value, Options) ->
   State    = jesse_state:new(JsonSchema, Options),
-  Schema   = [{<<"$ref">>, Ref}],
+  Schema   = make_definition_ref(Defintion),
   NewState = validate_with_state(Schema, Value, State),
   {result(NewState), Value}.
 
@@ -133,3 +133,10 @@ run_validator(Validator, Value, [Attr | Attrs], State0) ->
                                , State0
                                ),
   run_validator(Validator, Value, Attrs, State).
+
+%% @doc Makes a $ref schema object pointing to the given `Definition'
+%% in schema defintions.
+%% @private
+make_definition_ref(Definition) ->
+  Definition1 = list_to_binary(Definition),
+  [{<<"$ref">>, <<"#/definitions/", Definition1/binary>>}].

--- a/src/jesse_schema_validator.erl
+++ b/src/jesse_schema_validator.erl
@@ -40,7 +40,13 @@
     Attr  :: {binary(), jesse:json_term()},
     State :: jesse_state:state().
 
--callback init_state() -> any() | undefined.
+-callback init_state(Opts :: jesse_state:validator_opts()) ->
+    validator_state().
+
+-type validator_state() :: any().
+
+-export_type([ validator_state/0
+             ]).
 
 %%% API
 %% @doc Validates json `Data' against `JsonSchema' with `Options'.

--- a/src/jesse_state.erl
+++ b/src/jesse_state.erl
@@ -53,6 +53,8 @@
 -include("jesse_schema_validator.hrl").
 
 %% Internal datastructures
+-type http_uri() :: string().
+
 -record( state
        , { root_schema        :: jesse:json_term()
          , current_schema     :: jesse:json_term()
@@ -73,7 +75,7 @@
                                           jesse:json_term() |
                                           ?not_found
                                             )
-         , id                 :: http_uri:uri() | 'undefined'
+         , id                 :: http_uri() | 'undefined'
          }
        ).
 
@@ -312,8 +314,8 @@ load_local_schema(Schema, [Key | Keys]) ->
 
 %% @doc Resolve a new id
 %% @private
--spec combine_id(undefined | http_uri:uri(),
-                 undefined | binary()) -> http_uri:uri().
+-spec combine_id(undefined | http_uri(),
+                 undefined | binary()) -> http_uri().
 combine_id(Id, undefined) ->
   Id;
 combine_id(Id, RefBin) ->

--- a/src/jesse_state.erl
+++ b/src/jesse_state.erl
@@ -47,6 +47,7 @@
         ]).
 
 -export_type([ state/0
+             , validator_opts/0
              ]).
 
 %% Includes
@@ -80,6 +81,8 @@
        ).
 
 -opaque state() :: #state{}.
+
+-type validator_opts() :: any().
 
 %%% API
 %% @doc Adds `Property' to the `current_path' in `State'.
@@ -165,7 +168,13 @@ new(JsonSchema, Options) ->
                                         , Options
                                         , undefined
                                         ),
-  ValidatorState   = init_validator_state(Validator),
+  ValidatorOpts    = proplists:get_value( validator_opts
+                                        , Options
+                                        , undefined
+                                        ),
+  ValidatorState   = init_validator_state( Validator
+                                         , ValidatorOpts
+                                         ),
   LoaderFun        = proplists:get_value( schema_loader_fun
                                         , Options
                                         , ?default_schema_loader_fun
@@ -269,11 +278,13 @@ undo_resolve_ref(RefState, OriginalState) ->
 
 %% @doc Init custom validator state.
 %% @private
--spec init_validator_state(Validator :: module() | undefined) -> any() | undefined.
-init_validator_state(undefined) ->
+-spec init_validator_state( Validator :: module() | undefined
+                          , Opts :: validator_opts()
+                          ) -> jesse_schema_validator:validator_state().
+init_validator_state(undefined, _) ->
   undefined;
-init_validator_state(Validator) ->
-  Validator:init_state().
+init_validator_state(Validator, Opts) ->
+  Validator:init_state(Opts).
 
 %% @doc Retrieve a specific part of a schema
 %% @private

--- a/src/jesse_validator_draft3.erl
+++ b/src/jesse_validator_draft3.erl
@@ -63,168 +63,146 @@ init_state() ->
 
 %% @doc Validates the value `Value' against the attributes
 %% of the given schema `JsonSchema'.
--spec check_value(Value, JsonSchema, State) ->
-  {Value, JsonSchema, State} | no_return()
+-spec check_value(Value, Attr, State) ->
+  State | no_return()
     when
-    Value      :: any(),
-    JsonSchema :: jesse:json_term(),
-    State      :: jesse_state:state().
-check_value(Value, [{?TYPE, Type} | Attrs], State) ->
-  NewState = check_type(Value, Type, State),
-  {Value, Attrs, NewState};
-check_value(Value, [{?PROPERTIES, Properties} | Attrs], State) ->
-  NewState = case jesse_lib:is_json_object(Value) of
-               true  -> check_properties( Value
-                                        , unwrap(Properties)
+    Value :: any(),
+    Attr  :: {binary(), jesse:json_term()},
+    State :: jesse_state:state().
+check_value(Value, {?TYPE, Type}, State) ->
+  check_type(Value, Type, State);
+check_value(Value, {?PROPERTIES, Properties}, State) ->
+  case jesse_lib:is_json_object(Value) of
+    true  -> check_properties( Value
+                             , unwrap(Properties)
+                             , State
+                             );
+    false -> State
+  end;
+check_value( Value
+           , {?PATTERNPROPERTIES, PatternProperties}
+           , State
+           ) ->
+  case jesse_lib:is_json_object(Value) of
+    true  -> check_pattern_properties( Value
+                                     , PatternProperties
+                                     , State
+                                     );
+    false -> State
+  end;
+check_value( Value
+           , {?ADDITIONALPROPERTIES, AdditionalProperties}
+           , State
+           ) ->
+  case jesse_lib:is_json_object(Value) of
+    true  -> check_additional_properties( Value
+                                        , AdditionalProperties
                                         , State
                                         );
-               false -> State
-             end,
-  {Value, Attrs, NewState};
-check_value( Value
-           , [{?PATTERNPROPERTIES, PatternProperties} | Attrs]
-           , State
-           ) ->
-  NewState = case jesse_lib:is_json_object(Value) of
-               true  -> check_pattern_properties( Value
-                                                , PatternProperties
-                                                , State
-                                                );
-               false -> State
-             end,
-  {Value, Attrs, NewState};
-check_value( Value
-           , [{?ADDITIONALPROPERTIES, AdditionalProperties} | Attrs]
-           , State
-           ) ->
-  NewState = case jesse_lib:is_json_object(Value) of
-               true  -> check_additional_properties( Value
-                                                   , AdditionalProperties
-                                                   , State
-                                                   );
-               false -> State
-       end,
-  {Value, Attrs, NewState};
-check_value(Value, [{?ITEMS, Items} | Attrs], State) ->
-  NewState = case jesse_lib:is_array(Value) of
-               true  -> check_items(Value, Items, State);
-               false -> State
-             end,
-  {Value, Attrs, NewState};
+    false -> State
+  end;
+check_value(Value, {?ITEMS, Items}, State) ->
+  case jesse_lib:is_array(Value) of
+    true  -> check_items(Value, Items, State);
+    false -> State
+  end;
 %% doesn't really do anything, since this attribute will be handled
 %% by the previous function clause if it's presented in the schema
-check_value( Value
-           , [{?ADDITIONALITEMS, _AdditionalItems} | Attrs]
+check_value( _Value
+           , {?ADDITIONALITEMS, _AdditionalItems}
            , State
            ) ->
-  {Value, Attrs, State};
+  State;
 %% doesn't really do anything, since this attribute will be handled
 %% by the previous function clause if it's presented in the schema
-check_value(Value, [{?REQUIRED, _Required} | Attrs], State) ->
-  {Value, Attrs, State};
-check_value(Value, [{?DEPENDENCIES, Dependencies} | Attrs], State) ->
-  NewState = case jesse_lib:is_json_object(Value) of
-               true  -> check_dependencies(Value, Dependencies, State);
-               false -> State
-             end,
-  {Value, Attrs, NewState};
-check_value(Value, [{?MINIMUM, Minimum} | Attrs], State) ->
-  NewState = case is_number(Value) of
-               true  ->
-                 ExclusiveMinimum = get_value( ?EXCLUSIVEMINIMUM
-                                             , get_current_schema(State)
-                                             ),
-                 check_minimum(Value, Minimum, ExclusiveMinimum, State);
-               false ->
-                 State
-             end,
-  {Value, Attrs, NewState};
-check_value(Value, [{?MAXIMUM, Maximum} | Attrs], State) ->
-  NewState = case is_number(Value) of
-               true  ->
-                 ExclusiveMaximum = get_value( ?EXCLUSIVEMAXIMUM
-                                             , get_current_schema(State)
-                                             ),
-                 check_maximum(Value, Maximum, ExclusiveMaximum, State);
-               false ->
-                 State
-             end,
-  {Value, Attrs, NewState};
+check_value(_Value, {?REQUIRED, _Required}, State) ->
+  State;
+check_value(Value, {?DEPENDENCIES, Dependencies}, State) ->
+  case jesse_lib:is_json_object(Value) of
+    true  -> check_dependencies(Value, Dependencies, State);
+    false -> State
+  end;
+check_value(Value, {?MINIMUM, Minimum}, State) ->
+  case is_number(Value) of
+    true  ->
+      ExclusiveMinimum = get_value( ?EXCLUSIVEMINIMUM
+                                  , get_current_schema(State)
+                                  ),
+      check_minimum(Value, Minimum, ExclusiveMinimum, State);
+    false ->
+      State
+  end;
+check_value(Value, {?MAXIMUM, Maximum}, State) ->
+  case is_number(Value) of
+    true  ->
+      ExclusiveMaximum = get_value( ?EXCLUSIVEMAXIMUM
+                                  , get_current_schema(State)
+                                  ),
+      check_maximum(Value, Maximum, ExclusiveMaximum, State);
+    false ->
+      State
+  end;
 %% doesn't really do anything, since this attribute will be handled
 %% by the previous function clause if it's presented in the schema
-check_value( Value
-           , [{?EXCLUSIVEMINIMUM, _ExclusiveMinimum} | Attrs]
+check_value( _Value
+           , {?EXCLUSIVEMINIMUM, _ExclusiveMinimum}
            , State
            ) ->
-  {Value, Attrs, State};
+  State;
 %% doesn't really do anything, since this attribute will be handled
 %% by the previous function clause if it's presented in the schema
-check_value( Value
-           , [{?EXCLUSIVEMAXIMUM, _ExclusiveMaximum} | Attrs]
+check_value( _Value
+           , {?EXCLUSIVEMAXIMUM, _ExclusiveMaximum}
            , State
            ) ->
-  {Value, Attrs, State};
-check_value(Value, [{?MINITEMS, MinItems} | Attrs], State) ->
-  NewState = case jesse_lib:is_array(Value) of
-               true  -> check_min_items(Value, MinItems, State);
-               false -> State
-             end,
-  {Value, Attrs, NewState};
-check_value(Value, [{?MAXITEMS, MaxItems} | Attrs], State) ->
-  NewState = case jesse_lib:is_array(Value) of
-               true  -> check_max_items(Value, MaxItems, State);
-               false -> State
-             end,
-  {Value, Attrs, NewState};
-check_value(Value, [{?UNIQUEITEMS, Uniqueitems} | Attrs], State) ->
-  NewState = case jesse_lib:is_array(Value) of
-               true  -> check_unique_items(Value, Uniqueitems, State);
-               false -> State
-             end,
-  {Value, Attrs, NewState};
-check_value(Value, [{?PATTERN, Pattern} | Attrs], State) ->
-  NewState = case is_binary(Value) of
-               true  -> check_pattern(Value, Pattern, State);
-               false -> State
-             end,
-  {Value, Attrs, NewState};
-check_value(Value, [{?MINLENGTH, MinLength} | Attrs], State) ->
-  NewState = case is_binary(Value) of
-               true  -> check_min_length(Value, MinLength, State);
-               false -> State
-  end,
-  {Value, Attrs, NewState};
-check_value(Value, [{?MAXLENGTH, MaxLength} | Attrs], State) ->
-  NewState = case is_binary(Value) of
-               true  -> check_max_length(Value, MaxLength, State);
-               false -> State
-             end,
-  {Value, Attrs, NewState};
-check_value(Value, [{?ENUM, Enum} | Attrs], State) ->
-  NewState = check_enum(Value, Enum, State),
-  {Value, Attrs, NewState};
-check_value(Value, [{?FORMAT, Format} | Attrs], State) ->
-  NewState = check_format(Value, Format, State),
-  {Value, Attrs, NewState};
-check_value(Value, [{?DIVISIBLEBY, DivisibleBy} | Attrs], State) ->
-  NewState = case is_number(Value) of
-               true  -> check_divisible_by(Value, DivisibleBy, State);
-               false -> State
-             end,
-  {Value, Attrs, NewState};
-check_value(Value, [{?DISALLOW, Disallow} | Attrs], State) ->
-  NewState = check_disallow(Value, Disallow, State),
-  {Value, Attrs, NewState};
-check_value(Value, [{?EXTENDS, Extends} | Attrs], State) ->
-  NewState = check_extends(Value, Extends, State),
-  {Value, Attrs, NewState};
-check_value(Value, [], State) ->
-  {Value, [], State};
-check_value(Value, [{?REF, RefSchemaURI} | Attrs], State) ->
-  NewState = validate_ref(Value, RefSchemaURI, State),
-  {Value, Attrs, NewState};
-check_value(Value, [_Attr | Attrs], State) ->
-  {Value, Attrs, State}.
+  State;
+check_value(Value, {?MINITEMS, MinItems}, State) ->
+  case jesse_lib:is_array(Value) of
+    true  -> check_min_items(Value, MinItems, State);
+    false -> State
+  end;
+check_value(Value, {?MAXITEMS, MaxItems}, State) ->
+  case jesse_lib:is_array(Value) of
+    true  -> check_max_items(Value, MaxItems, State);
+    false -> State
+  end;
+check_value(Value, {?UNIQUEITEMS, Uniqueitems}, State) ->
+  case jesse_lib:is_array(Value) of
+    true  -> check_unique_items(Value, Uniqueitems, State);
+    false -> State
+  end;
+check_value(Value, {?PATTERN, Pattern}, State) ->
+  case is_binary(Value) of
+    true  -> check_pattern(Value, Pattern, State);
+    false -> State
+  end;
+check_value(Value, {?MINLENGTH, MinLength}, State) ->
+  case is_binary(Value) of
+    true  -> check_min_length(Value, MinLength, State);
+    false -> State
+  end;
+check_value(Value, {?MAXLENGTH, MaxLength}, State) ->
+  case is_binary(Value) of
+    true  -> check_max_length(Value, MaxLength, State);
+    false -> State
+  end;
+check_value(Value, {?ENUM, Enum}, State) ->
+  check_enum(Value, Enum, State);
+check_value(Value, {?FORMAT, Format}, State) ->
+  check_format(Value, Format, State);
+check_value(Value, {?DIVISIBLEBY, DivisibleBy}, State) ->
+  case is_number(Value) of
+    true  -> check_divisible_by(Value, DivisibleBy, State);
+    false -> State
+  end;
+check_value(Value, {?DISALLOW, Disallow}, State) ->
+  check_disallow(Value, Disallow, State);
+check_value(Value, {?EXTENDS, Extends}, State) ->
+  check_extends(Value, Extends, State);
+check_value(Value, {?REF, RefSchemaURI}, State) ->
+  validate_ref(Value, RefSchemaURI, State);
+check_value(_Value, _Attr, State) ->
+  State.
 
 %%% Internal functions
 %% @doc Adds Property to the current path and checks the value

--- a/src/jesse_validator_draft3.erl
+++ b/src/jesse_validator_draft3.erl
@@ -25,7 +25,7 @@
 -behaviour(jesse_schema_validator).
 
 %% API
--export([ init_state/0
+-export([ init_state/1
         , check_value/3
         ]).
 
@@ -57,8 +57,8 @@
 
 %%% API
 %% @doc Behaviour callback. Custom state is not used by this validator.
--spec init_state() -> undefined.
-init_state() ->
+-spec init_state(_) -> undefined.
+init_state(_) ->
   undefined.
 
 %% @doc Validates the value `Value' against the attributes

--- a/src/jesse_validator_draft4.erl
+++ b/src/jesse_validator_draft4.erl
@@ -25,7 +25,7 @@
 -behaviour(jesse_schema_validator).
 
 %% API
--export([ init_state/0
+-export([ init_state/1
         , check_value/3
         ]).
 
@@ -74,8 +74,8 @@
 
 %%% API
 %% @doc Behaviour callback. Custom state is not used by this validator.
--spec init_state() -> undefined.
-init_state() ->
+-spec init_state(_) -> undefined.
+init_state(_) ->
   undefined.
 
 %% @doc Validates the value `Value' against the attributes

--- a/test/Generic-Test-Suite/customValidator.json
+++ b/test/Generic-Test-Suite/customValidator.json
@@ -1,0 +1,36 @@
+[
+    {
+        "description": "use custom validator",
+        "schema": {
+            "customDef": "testSuccess",
+            "properties": {
+                "testSuccess": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "testSuccess"
+            ]
+        },
+        "tests": [
+            {
+                "description": "custom validation success",
+                "data": {"testSuccess": true},
+                "valid": true
+            },
+            {
+                "description": "custom validation failure",
+                "data": {"testSuccess": false},
+                "valid": false
+            },
+            {
+                "description": "base validation failure",
+                "data": {"wrongProperty": "whatever"},
+                "valid": false
+            }
+        ],
+        "options": {
+            "validator": "jesse_tests_generic_SUITE"
+        }
+    }
+]

--- a/test/jesse_tests_generic_SUITE.erl
+++ b/test/jesse_tests_generic_SUITE.erl
@@ -59,19 +59,18 @@ end_per_suite(_Config) ->
 init_state() ->
   0.
 
-check_value(Value, [{<<"customDef">>, Property} | Attrs], State0) ->
+check_value(Value, {<<"customDef">>, Property}, State0) ->
   State = update_custom_state(State0),
-  NewState = case jesse_json_path:path(Property, Value) of
-               true  -> State;
-               false -> jesse_error:handle_data_invalid( 'custom_validator_reject'
-                                                       , Value
-                                                       , State);
-               %% Skip if custom property is missing
-               [] -> State
-  end,
-  {Value, Attrs, NewState};
-check_value(Value, JsonSchema, State) ->
-  jesse_validator_draft4:check_value(Value, JsonSchema, State).
+  case jesse_json_path:path(Property, Value) of
+    true  -> State;
+    false -> jesse_error:handle_data_invalid( 'custom_validator_reject'
+                                            , Value
+                                            , State);
+    %% Skip if custom property is missing
+    [] -> State
+  end;
+check_value(Value, Attr, State) ->
+  jesse_validator_draft4:check_value(Value, Attr, State).
 
 update_custom_state(State) ->
   ValidatorState = 0 = jesse_state:get_validator_state(State),

--- a/test/jesse_tests_generic_SUITE.erl
+++ b/test/jesse_tests_generic_SUITE.erl
@@ -1,0 +1,83 @@
+%%%=============================================================================
+%% Copyright 2012- Klarna AB
+%% Copyright 2015- AUTHORS
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%%
+%% @doc jesse test suite which covers generic jessy functionality
+%% (not schema specific).
+%% @end
+%%%=============================================================================
+
+-module(jesse_tests_generic_SUITE).
+
+-behaviour(jesse_schema_validator).
+
+-compile([ export_all
+         ]).
+
+-define(EXCLUDED_FUNS, [ module_info
+                       , all
+                       , init_per_suite
+                       , end_per_suite
+                       , init_state
+                       , check_value
+                       , update_custom_state
+                       ]).
+
+-include_lib("common_test/include/ct.hrl").
+
+-import(jesse_tests_util, [ get_tests/2
+                          , do_test/2
+                          ]).
+
+all() ->
+  Exports = ?MODULE:module_info(exports),
+  [F || {F, _} <- Exports, not lists:member(F, ?EXCLUDED_FUNS)].
+
+init_per_suite(Config) ->
+  inets:start(),
+  get_tests( "Generic-Test-Suite"
+           , <<"http://json-schema.org/draft-04/schema#">>
+           )
+    ++ Config.
+
+end_per_suite(_Config) ->
+  inets:stop().
+
+init_state() ->
+  0.
+
+check_value(Value, [{<<"customDef">>, Property} | Attrs], State0) ->
+  State = update_custom_state(State0),
+  NewState = case jesse_json_path:path(Property, Value) of
+               true  -> State;
+               false -> jesse_error:handle_data_invalid( 'custom_validator_reject'
+                                                       , Value
+                                                       , State);
+               %% Skip if custom property is missing
+               [] -> State
+  end,
+  {Value, Attrs, NewState};
+check_value(Value, JsonSchema, State) ->
+  jesse_validator_draft4:check_value(Value, JsonSchema, State).
+
+update_custom_state(State) ->
+  ValidatorState = 0 = jesse_state:get_validator_state(State),
+  jesse_state:set_validator_state(State, ValidatorState + 1).
+
+%%% Testcases
+
+additionalItems(Config) ->
+  do_test("customValidator", Config).

--- a/test/jesse_tests_generic_SUITE.erl
+++ b/test/jesse_tests_generic_SUITE.erl
@@ -56,7 +56,7 @@ init_per_suite(Config) ->
 end_per_suite(_Config) ->
   inets:stop().
 
-init_state() ->
+init_state(_) ->
   0.
 
 check_value(Value, {<<"customDef">>, Property}, State0) ->


### PR DESCRIPTION
Hi, I'd propose a bit different approach to external validators: allow pluggable validator modules which follow validator interface, the same as used for _draft3_ and _draft4_ validators, and can be built on top of those default validators as well as override any rule or implement totally independent validation logic. I think, that is rather more flexible approach, than just allowing some post validation after all the default rules have been successfully validated. It will also allow to update `jesse_validator_draft4` code, removing unnecessary code duplication with `jesse_validator_draft3`.

This PR also introduces `jesse:validate_definition/3/4` interface to validate a value against a particular definition in the `definitions` section of a schema.

I see, that you've just merged alternative implementation for external validators (I should have created this PR some weeks ago!), thou I hope you'll consider this PR. If you find this PR interesting and I'll prepare it for the merge (rebase, etc).