### PR TITLE
Correct schema on error

### DIFF
--- a/src/jesse_error.erl
+++ b/src/jesse_error.erl
@@ -109,20 +109,24 @@ to_json({error, Reasons}, JsxOptions) ->
 
 %% @doc Convert an error reason to jsx structs
 -spec reason_to_jsx(Reason :: error_reason()) -> jesse:json_term().
-reason_to_jsx({?schema_invalid, Schema, {Error, _}}) ->
+reason_to_jsx({?schema_invalid, Schema, {Error, Value}}) ->
   [ {invalid, schema}
   , {schema, Schema}
-  , {error, Error}
+  , {error, [ {<<"type">>, Error}
+            , {<<"value">>, Value}
+            ]}
   ];
 reason_to_jsx({?schema_invalid, Schema, Error}) ->
   [ {invalid, schema}
   , {schema, Schema}
   , {error, Error}
   ];
-reason_to_jsx({?data_invalid, Schema, {Error, _}, Data, Path}) ->
+reason_to_jsx({?data_invalid, Schema, {Error, Value}, Data, Path}) ->
   [ {invalid, data}
   , {schema, Schema}
-  , {error, Error}
+  , {error, [ {<<"type">>, Error}
+            , {<<"value">>, Value}
+            ]}
   , {data, Data}
   , {path, Path}
   ];

--- a/src/jesse_validator_draft3.erl
+++ b/src/jesse_validator_draft3.erl
@@ -361,10 +361,13 @@ check_properties(Value, Properties, State) ->
 %% @end
                            case get_value(?REQUIRED, PropertySchema) of
                              true ->
+                               NewState = set_current_schema( CurrentState
+                                                            , PropertySchema
+                                                            ),
                                handle_data_invalid( {?missing_required_property
                                                      , PropertyName}
                                                    , Value
-                                                   , CurrentState);
+                                                   , NewState);
                              _    ->
                                CurrentState
                            end;


### PR DESCRIPTION
When validating a draft 03 json with a missing required property, the schema that is displayed is the previous property, not the the offending one. Here is a minimal sample schema:

```
{
    "$schema": "http://json-schema.org/draft-03/schema#",
    "type": "object",
    "properties": {
        "moose_value": {
            "required": true,
            "type": "number",
            "minimum": 0,
            "description": "This should not be displayed"
        },
        "sausage_version": {
            "required": true,
            "type": "integer",
            "description": "This should be displayed when we fail."
        }
    }
}
```

And here is an invalid json, not the misspelled second property:

```
{"moose_value":5.0e+02,"sausage_venison":4}
```

This is the current behavior:
```$ ./bin/jesse error_schema_draft_03.json -- error_data.json
[{filename,<<"error_data.json">>},
 {result,error},
 {errors,[[{invalid,data},
           {schema,[{<<"required">>,false},
                    {<<"type">>,<<"number">>},
                    {<<"minimum">>,0},
                    {<<"description">>,<<"This should not be displayed">>}]},
           {error,missing_required_property},
           {data,[{<<"moose_value">>,500.0},{<<"sausage_venison">>,4}]},
           {path,[]}]]}]
```

Note how the required property is thrown away and the description is from the previous property.

This is the expected output, which is the output from this branch:
```$ ./bin/jesse error_schema_draft_03.json -- error_data.json
[{filename,<<"error_data.json">>},
 {result,error},
 {errors,[[{invalid,data},
           {schema,[{<<"required">>,true},
                    {<<"type">>,<<"integer">>},
                    {<<"description">>,
                     <<"This should be displayed when we fail.">>}]},
           {error,[{<<"type">>,missing_required_property},
                   {<<"value">>,<<"sausage_version">>}]},
           {data,[{<<"moose_value">>,500.0},{<<"sausage_venison">>,4}]},
           {path,[]}]]}]
```
