### PR TITLE
OTP 21 compatibility, or get_stacktrace workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: false
 language:
   - erlang
 otp_release:
+  - 21.0-rc1
   - 20.1
   - 20.0
   - 19.3

--- a/rebar.config
+++ b/rebar.config
@@ -3,6 +3,7 @@
           , "deps"
           ]}.
 {erl_opts, [ {platform_define, "^R[0-9]+", erlang_deprecated_types}
+           , {platform_define, "^(R[0-9]+|1[7-9]+|20)", erlang_deprecated_stacktrace}
              %% , warn_export_all
            , warn_export_vars
            , warn_obsolete_guard

--- a/src/jesse_state.erl
+++ b/src/jesse_state.erl
@@ -385,7 +385,6 @@ load_schema(#state{schema_loader_fun = LoaderFun}, SchemaURI) ->
         end
   catch
     _C:_E ->
-      %% io:format("load_schema: ~p\n", [{_C, _E, erlang:get_stacktrace()}]),
       ?not_found
   end.
 

--- a/src/jesse_tests_util.erl
+++ b/src/jesse_tests_util.erl
@@ -35,6 +35,12 @@
 -define(TESTS,       <<"tests">>).
 -define(VALID,       <<"valid">>).
 
+-ifdef(erlang_deprecated_stacktrace).
+-define(WITH_STACKTRACE(C, E, Stacktrace), C:E -> Stacktrace = erlang:get_stacktrace(),).
+-else.
+-define(WITH_STACKTRACE(C, E, Stacktrace), C:E:Stacktrace ->).
+-endif.
+
 %%% API
 
 get_tests(RelativeTestsDir, DefaultSchema) ->
@@ -90,10 +96,10 @@ test_schema(DefaultSchema, Opts0, Schema, SchemaTests) ->
                            false ->
                              {error, _} = Result
                          end
-                     catch C:E ->
+                     catch ?WITH_STACKTRACE(C, E, Stacktrace)
                          ct:pal( "Error: ~p:~p~n"
                                  "Stacktrace: ~p~n"
-                               , [C, E, erlang:get_stacktrace()]
+                               , [C, E, Stacktrace]
                                )
                      end
                  end


### PR DESCRIPTION
This PR adds workaround for OTP 21 deprecation of get_stackgrace function.
Also, Travis CI target of 21.0-rc1 is added.

(rc2 request: https://github.com/travis-ci/travis-ci/issues/9685 )

This PR is tested with:

- OTP 21.0-rc2
- OTP 21.0-rc1
- OTP 20.3.4
- OTP 19.3

The test script is : https://gist.github.com/shino/d14d26ed42bfe4aab81361b338780c3b
