### PR TITLE
add missing error types to handle json parser exceptions

### DIFF
--- a/src/jesse.erl
+++ b/src/jesse.erl
@@ -254,8 +254,8 @@ try_parse(Type, ParserFun, JsonBin) ->
     _:Error ->
       case Type of
         data ->
-          throw({data_error, {parse_error, Error}});
+          throw([{data_error, {parse_error, Error}}]);
         schema ->
-          throw({schema_error, {parse_error, Error}})
+          throw([{schema_error, {parse_error, Error}}])
       end
   end.

--- a/src/jesse_error.erl
+++ b/src/jesse_error.erl
@@ -46,7 +46,9 @@
                         , Error  :: error_type()
                         , Data   :: jesse:json_term()
                         , Path   :: [binary()]
-                        }.
+                        }
+                      | { data_error, {parse_error, _}}
+                      | { schema_error, {parse_error, _}}.
 
 -type error_type() :: atom()
                     | {atom(), jesse:json_term()}


### PR DESCRIPTION
I was trying to handle JSON parser error cases with validate, and found that on invalid json schema the return is `{error, {schema_error, {parse_error, _}}}` and on invalid data the same except with `{error, {data_error, ...}}`
Once I tried to match it to the return value dialyzer started complaining that it can never match....
` The pattern {'error', {'schema_error', {'parse_error', 'xxx'}}} can never match the type {'error',[{'schema_invalid',_,atom() | {atom(),_}} | {'data_invalid',_,atom() | {atom(),_},_,[binary()]}]} | {'ok',_}`

I've checked the spec and I've found the dialyzer is right.

I added this 2 error cases to the `jesse_error:error_reason()` type, and made it return as list to be more consistent.