### PR TITLE
Add validator draft3/draft4 schema unique check missed case

### DIFF
--- a/src/jesse_validator_draft3.erl
+++ b/src/jesse_validator_draft3.erl
@@ -750,6 +750,8 @@ check_max_items(Value, _MaxItems, State) ->
 %%       object.</li>
 %% </ul>
 %% @private
+check_unique_items(_, false, State) ->
+  State;
 check_unique_items([], true, State) ->
     State;
 check_unique_items(Value, true, State) ->

--- a/src/jesse_validator_draft4.erl
+++ b/src/jesse_validator_draft4.erl
@@ -824,6 +824,8 @@ check_max_items(Value, _MaxItems, State) ->
 %%   false.
 %%
 %% @private
+check_unique_items(_, false, State) ->
+  State;
 check_unique_items([], true, State) ->
   State;
 check_unique_items(Value, true, State) ->


### PR DESCRIPTION
Currently having a field with a type `{ "type": "array", "uniqueItems": false }` fails with a function clause during validation. I added a missed function case.