### PR TITLE
Work around unexported `http_uri:uri()` type

### DIFF
--- a/src/jesse.erl
+++ b/src/jesse.erl
@@ -77,7 +77,8 @@
 
 -type schema() :: json_term().
 
--type schema_id() :: http_uri:uri() | undefined.
+-type http_uri_uri() :: string() | unicode:unicode_binary(). %% From https://github.com/erlang/otp/blob/OTP-20.2.3/lib/inets/doc/src/http_uri.xml#L57
+-type schema_id() :: http_uri_uri() | undefined.
 
 -type schema_ref() :: binary().
 

--- a/src/jesse_state.erl
+++ b/src/jesse_state.erl
@@ -276,10 +276,12 @@ load_local_schema(Schema, [Key | Keys]) ->
       end
   end.
 
+-type http_uri_uri() :: string() | unicode:unicode_binary(). %% From https://github.com/erlang/otp/blob/OTP-20.2.3/lib/inets/doc/src/http_uri.xml#L57
+
 %% @doc Resolve a new id
 %% @private
--spec combine_id(undefined | http_uri:uri(),
-                 undefined | string() | binary()) -> http_uri:uri().
+-spec combine_id(undefined | http_uri_uri(),
+                 undefined | string() | binary()) -> http_uri_uri().
 combine_id(Id, undefined) ->
   Id;
 combine_id(Id, RefBin) ->


### PR DESCRIPTION
This prevents warnings when an application passes the `unknown` option to
Dialyzer and depends on `jesse`.