### PR TITLE
Prevent dialyzer warnings for consumers using OTP up until 19

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,6 +3,7 @@
           , "deps"
           ]}.
 {erl_opts, [ {platform_define, "^R[0-9]+", erlang_deprecated_types}
+           ,  {platform_define, "^2", post19}
              %% , warn_export_all
            , warn_export_vars
            , warn_obsolete_guard

--- a/src/jesse.erl
+++ b/src/jesse.erl
@@ -43,6 +43,7 @@
              , external_validator/0
              , json_term/0
              , schema/0
+             , http_uri_uri/0
              , schema_id/0
              , schema_ref/0
              , schema_ver/0
@@ -77,7 +78,13 @@
 
 -type schema() :: json_term().
 
--type schema_id() :: http_uri:uri() | undefined.
+-ifdef(post19).
+-type http_uri_uri() :: http_uri:uri().
+-else.
+-type http_uri_uri() :: string() | binary().
+-endif.
+
+-type schema_id() :: undefined | http_uri_uri().
 
 -type schema_ref() :: binary().
 

--- a/src/jesse_state.erl
+++ b/src/jesse_state.erl
@@ -278,8 +278,8 @@ load_local_schema(Schema, [Key | Keys]) ->
 
 %% @doc Resolve a new id
 %% @private
--spec combine_id(undefined | http_uri:uri(),
-                 undefined | string() | binary()) -> http_uri:uri().
+-spec combine_id(undefined | jesse:http_uri_uri(),
+                 undefined | string() | binary()) -> jesse:http_uri_uri().
 combine_id(Id, undefined) ->
   Id;
 combine_id(Id, RefBin) ->


### PR DESCRIPTION
`http_uri:uri()` was only exported on OTP 20+