### PR TITLE
Fixes for dialyzer

### DIFF
--- a/src/jesse.erl
+++ b/src/jesse.erl
@@ -152,7 +152,7 @@ del_schema(Key) ->
 %% where `ValidationFun' is `fun jesse_json:is_json_object/1'.
 -spec load_schemas( Path :: string()
                   , ParserFun :: fun((binary()) -> json_term())
-                  ) -> jesse_database:update_result().
+                  ) -> jesse_database:store_result().
 load_schemas(Path, ParserFun) ->
   load_schemas( Path
               , ParserFun
@@ -177,7 +177,7 @@ load_schemas(Path, ParserFun) ->
 -spec load_schemas( Path :: string()
                   , ParserFun :: parser_fun()
                   , ValidationFun :: validation_fun()
-                  ) -> jesse_database:update_result().
+                  ) -> jesse_database:store_result().
 load_schemas(Path, ParserFun, ValidationFun) ->
   jesse_database:add_path(Path, ParserFun, ValidationFun).
 

--- a/src/jesse_error.erl
+++ b/src/jesse_error.erl
@@ -66,7 +66,7 @@
 %% throws an exeption, otherwise adds a new element to the list and returs it.
 -spec default_error_handler( Error         :: error_reason()
                            , ErrorList     :: [error_reason()]
-                           , AllowedErrors :: jesse_state:allowed_errors()
+                           , AllowedErrors :: jesse:allowed_errors()
                            ) -> [error_reason()] | no_return().
 default_error_handler(Error, ErrorList0, AllowedErrors) ->
   ErrorList = ErrorList0 ++ [Error],


### PR DESCRIPTION
There's also a bunch (4) of results for *... is a supertype of ...*. Would you be interested in having those _fixed_?

e.g. `string()` when we should have `[byte()]`