### PR TITLE
Specify build matrix "dist" for old OTP releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,27 @@
 sudo: false
 language:
   - erlang
-otp_release:
-  - 21.0
-  - 20.1
-  - 20.0
-  - 19.3
-  - 19.2
-  - 19.1
-  - 19.0
-  - 18.3
-  - 18.2
-  - 18.1
-  - 18.0
+
+matrix:
+  include:
+  - otp_release: 21.0
+  - otp_release: 20.1
+  - otp_release: 20.0
+  - otp_release: 19.3
+  - otp_release: 19.2
+    dist: trusty
+  - otp_release: 19.1
+    dist: trusty
+  - otp_release: 19.0
+    dist: trusty
+  - otp_release: 18.3
+    dist: trusty
+  - otp_release: 18.2
+    dist: trusty
+  - otp_release: 18.1
+    dist: trusty
+  - otp_release: 18.0
+    dist: trusty
 script:
   - LATEST_OTP_RELEASE=21.0
   - "[[ ${TRAVIS_OTP_RELEASE} != ${LATEST_OTP_RELEASE} ]] || make elvis"


### PR DESCRIPTION
See https://github.com/for-GET/jesse/pull/81#issuecomment-511797592

Travis are changing their environment, so, old OTP versions are only available on old Ubuntu dists.