### PR TITLE
Add external format validators option

### DIFF
--- a/src/jesse.erl
+++ b/src/jesse.erl
@@ -41,6 +41,8 @@
              , error_handler/0
              , error_list/0
              , external_validator/0
+             , external_format_validator/0
+             , external_format_validators_map/0
              , json_term/0
              , schema/0
              , schema_id/0
@@ -71,6 +73,9 @@
 -type external_validator() :: fun((json_term(), any()) -> any())
                             | undefined.
 
+-type external_format_validator() :: fun((json_term()) -> ok | error).
+-type external_format_validators_map() :: #{binary() => external_format_validator()}.
+
 %% From https://github.com/erlang/otp/blob/OTP-20.2.3/lib/inets/doc/src/http_uri.xml#L57
 -type http_uri_uri() :: string() | unicode:unicode_binary().
 
@@ -95,6 +100,7 @@
                 | {default_schema_ver, schema_ver()}
                 | {error_handler, error_handler()}
                 | {external_validator, external_validator()}
+                | {external_format_validators, external_format_validators_map()}
                 | {meta_schema_ver, schema_ver()}
                 | {parser_fun, parser_fun()}
                 | {schema_loader_fun, schema_loader_fun()}.

--- a/src/jesse_state.erl
+++ b/src/jesse_state.erl
@@ -27,6 +27,7 @@
 -export([ add_to_path/2
         , get_allowed_errors/1
         , get_external_validator/1
+        , get_external_format_validator/2
         , get_current_path/1
         , get_current_schema/1
         , get_current_schema_id/1
@@ -59,6 +60,7 @@
          , error_handler :: jesse:error_handler()
          , error_list :: jesse:error_list()
          , external_validator :: jesse:external_validator()
+         , external_format_validators :: jesse:external_format_validators_map()
          , id :: jesse:schema_id()
          , root_schema :: jesse:schema()
          , schema_loader_fun :: jesse:schema_loader_fun()
@@ -142,6 +144,10 @@ new(JsonSchema, Options) ->
   ExternalValidator = proplists:get_value( external_validator
                                          , Options
                                          ),
+  ExternalFormatValidators = proplists:get_value( external_format_validators
+                                                , Options
+                                                , #{}
+                                                ),
   LoaderFun = proplists:get_value( schema_loader_fun
                                  , Options
                                  , ?default_schema_loader_fun
@@ -154,6 +160,7 @@ new(JsonSchema, Options) ->
                    , default_schema_ver = DefaultSchemaVer
                    , schema_loader_fun  = LoaderFun
                    , external_validator = ExternalValidator
+                   , external_format_validators = ExternalFormatValidators
                    },
   set_current_schema(NewState, JsonSchema).
 
@@ -393,3 +400,7 @@ load_schema(#state{schema_loader_fun = LoaderFun}, SchemaURI) ->
 %% @private
 get_external_validator(#state{external_validator = Fun}) ->
   Fun.
+
+-spec get_external_format_validator(binary(), state()) -> jesse:external_format_validator() | undefined.
+get_external_format_validator(Format, #state{external_format_validators = Validators}) ->
+  maps:get(Format, Validators, undefined).

--- a/src/jesse_validator_draft3.erl
+++ b/src/jesse_validator_draft3.erl
@@ -837,8 +837,8 @@ check_enum(Value, Enum, State) ->
       handle_data_invalid(?not_in_enum, Value, State)
   end.
 
-check_format(_Value, _Format, State) ->
-  State.
+check_format(Value, Format, State) ->
+  maybe_external_check_format(Value, Format, State).
 
 %% @doc 5.24.  divisibleBy
 %%
@@ -1051,3 +1051,14 @@ maybe_external_check_value(Value, State) ->
     Fun ->
       Fun(Value, State)
   end.
+
+maybe_external_check_format(Value, Format, State) ->
+    case jesse_state:get_external_format_validator(Format, State) of
+        undefined -> State;
+        Fun when is_function(Fun, 1) ->
+            case Fun(Value) of
+                ok -> State;
+                error ->
+                    handle_data_invalid(?wrong_format, Value, State)
+            end
+    end.

--- a/src/jesse_validator_draft4.erl
+++ b/src/jesse_validator_draft4.erl
@@ -980,8 +980,8 @@ check_format(Value, _Format = <<"ipv6">>, State) when is_binary(Value) ->
 check_format(Value, _Format = <<"uri">>, State) when is_binary(Value) ->
   %% not yet supported
   State;
-check_format(_Value, _Format, State) ->
-  State.
+check_format(Value, Format, State) ->
+  maybe_external_check_format(Value, Format, State).
 
 %% @doc 5.1.1. multipleOf
 %%
@@ -1378,4 +1378,15 @@ maybe_external_check_value(Value, State) ->
       State;
     Fun ->
       Fun(Value, State)
+  end.
+
+maybe_external_check_format(Value, Format, State) ->
+  case jesse_state:get_external_format_validator(Format, State) of
+    undefined -> State;
+    Fun when is_function(Fun, 1) ->
+      case Fun(Value) of
+        ok -> State;
+        error ->
+          handle_data_invalid(?wrong_format, Value, State)
+      end
   end.


### PR DESCRIPTION
The idea is similar to `external_validator` option

This option allows you to define own string formats and validate it with any `fun(binary()) -> ok | error`.
For example: 

```
Validators = #{
   %% validates "IPV4:PORT" string, like "127.0.0.1:5050
   <<"ipv4_and_port">> => fun ipv4_and_port_validator/1
}, 
JesseOptions = [{external_format_validators, Validators}],
jesse:validate_with_schema(SchemaJson, ConfigJson, JesseOptions)
```
And somewhere in schema:
```
properties": {
    "str_key":   { "type": "string", "format": "ipv4_and_port" },
}
```
