### PR TITLE
Avoid deprecated http_uri functions for OTP 21+

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,6 +3,7 @@
           , "deps"
           ]}.
 {erl_opts, [ {platform_define, "^R[0-9]+", erlang_deprecated_types}
+           , {platform_define, "^(R[0-9]+|17|18|19|20)", http_uri_depricated_functions}
              %% , warn_export_all
            , warn_export_vars
            , warn_obsolete_guard

--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,6 @@
           , "deps"
           ]}.
 {erl_opts, [ {platform_define, "^R[0-9]+", erlang_deprecated_types}
-           , {platform_define, "^(R[0-9]+|17|18|19|20)", http_uri_depricated_functions}
              %% , warn_export_all
            , warn_export_vars
            , warn_obsolete_guard

--- a/src/jesse_json_path.erl
+++ b/src/jesse_json_path.erl
@@ -293,7 +293,7 @@ normalize(K, undefined) ->
 
 -spec parse_json_pointer_token(Token :: string()) -> binary().
 parse_json_pointer_token(Token) ->
-  DecodedToken = unicode:characters_to_binary(http_uri:decode(Token)),
+  DecodedToken = unicode:characters_to_binary(hex_decode(Token)),
   lists:foldl( fun({From, To}, T) ->
                    binary:replace(T, From, To)
                end
@@ -302,3 +302,16 @@ parse_json_pointer_token(Token) ->
                , {<<"~1">>, <<"/">>}
                ]
              ).
+
+%% @private
+hex_decode([$%, Hex1, Hex2 | Rest]) ->
+    [hex2dec(Hex1)*16 + hex2dec(Hex2) | hex_decode(Rest)];
+hex_decode([First | Rest]) ->
+    [First | hex_decode(Rest)];
+hex_decode([]) ->
+    [].
+
+%% @private
+hex2dec(X) when (X>=$0) andalso (X=<$9) -> X-$0;
+hex2dec(X) when (X>=$A) andalso (X=<$F) -> X-$A+10;
+hex2dec(X) when (X>=$a) andalso (X=<$f) -> X-$a+10.

--- a/src/jesse_json_path.erl
+++ b/src/jesse_json_path.erl
@@ -303,6 +303,9 @@ parse_json_pointer_token(Token) ->
                ]
              ).
 
+%% This implementation is based on http_uri:decode(), because there is
+%% no direct alternative inin uri_string module.
+%% cf. http://erlang.org/pipermail/erlang-questions/2020-March/099207.html
 %% @private
 hex_decode([$%, Hex1, Hex2 | Rest]) ->
     [hex2dec(Hex1)*16 + hex2dec(Hex2) | hex_decode(Rest)];

--- a/src/jesse_state.erl
+++ b/src/jesse_state.erl
@@ -410,7 +410,6 @@ parse_ref(RefBin) ->
     %% Absolute file:
     {error, {no_default_port, file, Ref}} ->
       {absolute, Ref};
-    %% Relative
     _ ->
       {relative, Ref}
   end.
@@ -418,10 +417,8 @@ parse_ref(RefBin) ->
 parse_ref(RefBin) ->
   Ref = unicode:characters_to_list(RefBin),
   case uri_string:parse(Ref) of
-    %% Absolute
     #{scheme := _} ->
       {absolute, Ref};
-    %% Relative
     _ ->
       {relative, Ref}
   end.

--- a/src/jesse_state.erl
+++ b/src/jesse_state.erl
@@ -400,7 +400,16 @@ get_external_validator(#state{external_validator = Fun}) ->
   Fun.
 
 %% @private
--ifdef(http_uri_depricated_functions).
+-ifdef(OTP_RELEASE). %% OTP 21+
+parse_ref(RefBin) ->
+  Ref = unicode:characters_to_list(RefBin),
+  case uri_string:parse(Ref) of
+    #{scheme := _} ->
+      {absolute, Ref};
+    _ ->
+      {relative, Ref}
+  end.
+-else.
 parse_ref(RefBin) ->
   Ref = unicode:characters_to_list(RefBin),
   case http_uri:parse(Ref) of
@@ -409,15 +418,6 @@ parse_ref(RefBin) ->
       {absolute, Ref};
     %% Absolute file:
     {error, {no_default_port, file, Ref}} ->
-      {absolute, Ref};
-    _ ->
-      {relative, Ref}
-  end.
--else.
-parse_ref(RefBin) ->
-  Ref = unicode:characters_to_list(RefBin),
-  case uri_string:parse(Ref) of
-    #{scheme := _} ->
       {absolute, Ref};
     _ ->
       {relative, Ref}

--- a/src/jesse_state.erl
+++ b/src/jesse_state.erl
@@ -295,16 +295,11 @@ load_local_schema(Schema, [Key | Keys]) ->
 combine_id(Id, undefined) ->
   Id;
 combine_id(Id, RefBin) ->
-  Ref = unicode:characters_to_list(RefBin),
-  case http_uri:parse(Ref) of
-    %% Absolute http/s:
-    {ok, _} ->
-      Ref;
-    %% Absolute file:
-    {error, {no_default_port, file, Ref}} ->
+  case parse_ref(RefBin) of
+    {absolute, Ref} ->
       Ref;
     %% Relative
-    _ ->
+    {relative, Ref} ->
       combine_relative_id(Id, Ref)
   end.
 
@@ -403,3 +398,31 @@ load_schema(#state{schema_loader_fun = LoaderFun}, SchemaURI) ->
 %% @private
 get_external_validator(#state{external_validator = Fun}) ->
   Fun.
+
+%% @private
+-ifdef(http_uri_depricated_functions).
+parse_ref(RefBin) ->
+  Ref = unicode:characters_to_list(RefBin),
+  case http_uri:parse(Ref) of
+    %% Absolute http/s:
+    {ok, _} ->
+      {absolute, Ref};
+    %% Absolute file:
+    {error, {no_default_port, file, Ref}} ->
+      {absolute, Ref};
+    %% Relative
+    _ ->
+      {relative, Ref}
+  end.
+-else.
+parse_ref(RefBin) ->
+  Ref = unicode:characters_to_list(RefBin),
+  case uri_string:parse(Ref) of
+    %% Absolute
+    #{scheme := _} ->
+      {absolute, Ref};
+    %% Relative
+    _ ->
+      {relative, Ref}
+  end.
+-endif.


### PR DESCRIPTION
When compiling with OTP 23-rc1, deprecated warnings are emmited for two http_uri functions, `parse` and `decode`.

In this PR:
- for OTP 21+, `parse` is replaced by `uri_string:parse`.
- `decode` is replaced by module private `hex_decode` function which is based on `http_uri:decode` code, because I can not find alternative in `uri_string` module.
