### PR TITLE
[#90] improve error messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ distclean:
 	$(RM) doc/stylesheet.css
 	$(RM) -r logs
 
+.PHONY: clean-tests
+clean-tests:
+	@ rm -rf _build/test/lib
 # Docs
 
 .PHONY: docs
@@ -53,10 +56,14 @@ test: eunit ct xref dialyzer cover
 
 .PHONY: eunit
 eunit:
+	@ $(MAKE) clean-tests
 	$(REBAR) eunit
+
+# @ rm -rf _build
 
 .PHONY: ct
 ct: test/JSON-Schema-Test-Suite/tests
+	@ $(MAKE) clean-tests
 	$(REBAR) ct
 
 .PHONY: xref
@@ -73,4 +80,5 @@ elvis:
 
 .PHONY: cover
 cover:
+	@ $(MAKE) clean-tests
 	$(REBAR) cover -v

--- a/src/jesse_error.erl
+++ b/src/jesse_error.erl
@@ -56,7 +56,8 @@
 
 -type error_type() :: atom()
                     | {atom(), jesse:json_term()}
-                    | {atom(), binary()}.
+                    | {atom(), binary()}
+                    | {atom(), [error_reason()]}.
 
 %% Includes
 -include("jesse_schema_validator.hrl").

--- a/src/jesse_schema_validator.hrl
+++ b/src/jesse_schema_validator.hrl
@@ -122,6 +122,7 @@
 -define(any_schemas_not_valid,       'any_schemas_not_valid').
 -define(not_multiple_of,             'not_multiple_of').
 -define(not_one_schema_valid,        'not_one_schema_valid').
+-define(more_than_one_schema_valid,  'more_than_one_schema_valid').
 -define(not_schema_valid,            'not_schema_valid').
 -define(wrong_not_schema,            'wrong_not_schema').
 -define(external,                    'external').

--- a/test/jesse_schema_validator_tests.erl
+++ b/test/jesse_schema_validator_tests.erl
@@ -221,6 +221,70 @@ schema_unsupported_test() ->
               , jesse_schema_validator:validate(UnsupportedSchema, Json, [])
               ).
 
+data_invalid_one_of_test() ->
+  IntegerSchema = {[{<<"type">>, <<"integer">>}]},
+  StringSchema  = {[{<<"type">>, <<"string">>}]},
+  ObjectSchema  = {[ {<<"type">>, <<"object">>}
+                   , { <<"properties">>
+                     , [ {<<"name">>, StringSchema}
+                       , {<<"age">>, IntegerSchema}
+                       ]
+                     }
+                   , {<<"additionalProperties">>, false}
+                   ]},
+
+  Schema = {[ {<<"$schema">>, <<"http://json-schema.org/draft-04/schema#">>}
+            , {<<"oneOf">>, [IntegerSchema, StringSchema, ObjectSchema]}
+            ]},
+
+  Json = [ {<<"name">>, 42}
+         , {<<"age">>, <<"John">>}
+         ],
+
+  ?assertThrow(
+     [ { data_invalid
+       , Schema
+       , { not_one_schema_valid
+         , [{data_invalid, IntegerSchema, wrong_type, Json, []}]
+         }
+       , Json
+       , []
+       }],
+     jesse_schema_validator:validate(Schema, Json, [])
+    ).
+
+data_invalid_any_of_test() ->
+  IntegerSchema = {[{<<"type">>, <<"integer">>}]},
+  StringSchema  = {[{<<"type">>, <<"string">>}]},
+  ObjectSchema  = {[ {<<"type">>, <<"object">>}
+                   , { <<"properties">>
+                     , [ {<<"name">>, StringSchema}
+                       , {<<"age">>, IntegerSchema}
+                       ]
+                     }
+                   , {<<"additionalProperties">>, false}
+                   ]},
+
+  Schema = {[ {<<"$schema">>, <<"http://json-schema.org/draft-04/schema#">>}
+            , {<<"anyOf">>, [IntegerSchema, StringSchema, ObjectSchema]}
+            ]},
+
+  Json = [ {<<"name">>, 42}
+         , {<<"age">>, <<"John">>}
+         ],
+
+  ?assertThrow(
+     [ { data_invalid
+       , Schema
+       , { any_schemas_not_valid
+         , [{data_invalid, IntegerSchema, wrong_type, Json, []}]
+         }
+       , Json
+       , []
+       }],
+     jesse_schema_validator:validate(Schema, Json, [])
+    ).
+
 -ifndef(erlang_deprecated_types).
 -ifndef(COMMON_TEST).  % see Emakefile
 map_schema_test() ->


### PR DESCRIPTION
### Description

Add internal errors for `oneOf`, `allOf` and `anyOf` to allow the user to figure out where the specific validation failed. 

Fixes #90.