### PR TITLE
[#90] Improve error messages (alternative)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ distclean:
 	$(RM) doc/stylesheet.css
 	$(RM) -r logs
 
+.PHONY: clean-tests
+clean-tests:
+	@ rm -rf _build/test/lib
 # Docs
 
 .PHONY: docs
@@ -53,10 +56,14 @@ test: eunit ct xref dialyzer cover
 
 .PHONY: eunit
 eunit:
+	@ $(MAKE) clean-tests
 	$(REBAR) eunit
+
+# @ rm -rf _build
 
 .PHONY: ct
 ct: test/JSON-Schema-Test-Suite/tests
+	@ $(MAKE) clean-tests
 	$(REBAR) ct
 
 .PHONY: xref
@@ -73,4 +80,5 @@ elvis:
 
 .PHONY: cover
 cover:
+	@ $(MAKE) clean-tests
 	$(REBAR) cover -v

--- a/src/jesse_error.erl
+++ b/src/jesse_error.erl
@@ -56,7 +56,8 @@
 
 -type error_type() :: atom()
                     | {atom(), jesse:json_term()}
-                    | {atom(), binary()}.
+                    | {atom(), binary()}
+                    | {atom(), [error_reason()]}.
 
 %% Includes
 -include("jesse_schema_validator.hrl").

--- a/src/jesse_schema_validator.hrl
+++ b/src/jesse_schema_validator.hrl
@@ -122,6 +122,7 @@
 -define(any_schemas_not_valid,       'any_schemas_not_valid').
 -define(not_multiple_of,             'not_multiple_of').
 -define(not_one_schema_valid,        'not_one_schema_valid').
+-define(more_than_one_schema_valid,  'more_than_one_schema_valid').
 -define(not_schema_valid,            'not_schema_valid').
 -define(wrong_not_schema,            'wrong_not_schema').
 -define(external,                    'external').

--- a/src/jesse_validator_draft4.erl
+++ b/src/jesse_validator_draft4.erl
@@ -1177,7 +1177,7 @@ check_any_of_(Value, [Schema | Schemas], State, Errors) ->
 %%
 %% @private
 check_one_of(Value, [_ | _] = Schemas, State) ->
-  check_one_of_(Value, Schemas, State, 0, empty);
+  check_one_of_(Value, Schemas, State, 0, []);
 check_one_of(_Value, _InvalidSchemas, State) ->
   handle_schema_invalid(?wrong_one_of_schema_array, State).
 
@@ -1197,12 +1197,11 @@ check_one_of_(Value, [Schema | Schemas], State, Valid, Errors) ->
         NumErrsBefore ->
           check_one_of_(Value, Schemas, NewState, Valid + 1, Errors);
         _  ->
-          NewErrors0 = ErrorsAfter -- ErrorsBefore,
-          NewErrors = shortest(NewErrors0, Errors),
-          check_one_of_(Value, Schemas, State, Valid, NewErrors)
+          NewErrors = ErrorsAfter -- ErrorsBefore,
+          check_one_of_(Value, Schemas, State, Valid, Errors ++ NewErrors)
       end;
     {false, NewErrors} ->
-      check_one_of_(Value, Schemas, State, Valid, shortest(NewErrors, Errors))
+      check_one_of_(Value, Schemas, State, Valid, Errors ++ NewErrors)
   end.
 
 %% @doc 5.5.6. not

--- a/test/jesse_schema_validator_tests.erl
+++ b/test/jesse_schema_validator_tests.erl
@@ -221,6 +221,70 @@ schema_unsupported_test() ->
               , jesse_schema_validator:validate(UnsupportedSchema, Json, [])
               ).
 
+data_invalid_one_of_test() ->
+  IntegerSchema = {[{<<"type">>, <<"integer">>}]},
+  StringSchema  = {[{<<"type">>, <<"string">>}]},
+  ObjectSchema  = {[ {<<"type">>, <<"object">>}
+                   , { <<"properties">>
+                     , [ {<<"name">>, StringSchema}
+                       , {<<"age">>, IntegerSchema}
+                       ]
+                     }
+                   , {<<"additionalProperties">>, false}
+                   ]},
+
+  Schema = {[ {<<"$schema">>, <<"http://json-schema.org/draft-04/schema#">>}
+            , {<<"oneOf">>, [IntegerSchema, StringSchema, ObjectSchema]}
+            ]},
+
+  Json = [ {<<"name">>, 42}
+         , {<<"age">>, <<"John">>}
+         ],
+
+  ?assertThrow(
+     [ { data_invalid
+       , Schema
+       , { not_one_schema_valid
+         , [{data_invalid, IntegerSchema, wrong_type, Json, []}]
+         }
+       , Json
+       , []
+       }],
+     jesse_schema_validator:validate(Schema, Json, [])
+    ).
+
+data_invalid_any_of_test() ->
+  IntegerSchema = {[{<<"type">>, <<"integer">>}]},
+  StringSchema  = {[{<<"type">>, <<"string">>}]},
+  ObjectSchema  = {[ {<<"type">>, <<"object">>}
+                   , { <<"properties">>
+                     , [ {<<"name">>, StringSchema}
+                       , {<<"age">>, IntegerSchema}
+                       ]
+                     }
+                   , {<<"additionalProperties">>, false}
+                   ]},
+
+  Schema = {[ {<<"$schema">>, <<"http://json-schema.org/draft-04/schema#">>}
+            , {<<"anyOf">>, [IntegerSchema, StringSchema, ObjectSchema]}
+            ]},
+
+  Json = [ {<<"name">>, 42}
+         , {<<"age">>, <<"John">>}
+         ],
+
+  ?assertThrow(
+     [ { data_invalid
+       , Schema
+       , { any_schemas_not_valid
+         , [{data_invalid, IntegerSchema, wrong_type, Json, []}]
+         }
+       , Json
+       , []
+       }],
+     jesse_schema_validator:validate(Schema, Json, [])
+    ).
+
 -ifndef(erlang_deprecated_types).
 -ifndef(COMMON_TEST).  % see Emakefile
 map_schema_test() ->

--- a/test/jesse_schema_validator_tests.erl
+++ b/test/jesse_schema_validator_tests.erl
@@ -245,7 +245,10 @@ data_invalid_one_of_test() ->
      [ { data_invalid
        , Schema
        , { not_one_schema_valid
-         , [{data_invalid, IntegerSchema, wrong_type, Json, []}]
+         , [ {data_invalid, IntegerSchema, wrong_type, Json, []}
+           , {data_invalid, StringSchema, wrong_type, Json, []}
+           , {data_invalid, StringSchema, wrong_type, 42, [<<"name">>]}
+           ]
          }
        , Json
        , []


### PR DESCRIPTION
This PR is an alternative to the approach taken in PR #91.

The difference is that in this PR, when a `oneOf` validation fails, the returned errors include all of the validation errors from each schema in the list of the `oneOf` schema.