### PR TITLE
default schema version is parent schema version

### DIFF
--- a/src/jesse_state.erl
+++ b/src/jesse_state.erl
@@ -221,7 +221,10 @@ resolve_ref(State, Reference) ->
                                            );
         RemoteSchema ->
           SchemaVer =
-            jesse_json_path:value(?SCHEMA, RemoteSchema, ?default_schema_ver),
+            jesse_json_path:value( ?SCHEMA
+                                 , RemoteSchema
+                                 , State#state.default_schema_ver
+                                 ),
           NewState = State#state{ root_schema = RemoteSchema
                                 , id = BaseURI
                                 , default_schema_ver = SchemaVer


### PR DESCRIPTION
Hello!

I provide to 

```erlang
    Result = jesse:validate("./" ++ binary_to_list(SchemaName), Data,
        [
            {default_schema_ver, <<"http://json-schema.org/draft-04/schema#">>}
        ]),
```

schema with $ref inside, and set draft-04 in options.

When jesse resolves refs it uses lib-wide default schema version draft-03. I think it's better to use parent schema version.

Thank you!