### PR TITLE
Adapt to higher-level consumption of `jsx`

### DIFF
--- a/src/jesse_cli.erl
+++ b/src/jesse_cli.erl
@@ -88,7 +88,7 @@ jesse_run(JsonInstance, Schema, Schemata) ->
   {ok, _} = application:ensure_all_started(jesse),
   ok = add_schemata(Schemata),
   {ok, JsonInstanceBinary} = file:read_file(JsonInstance),
-  JsonInstanceJsx = jsx:decode(JsonInstanceBinary),
+  JsonInstanceJsx = jsx:decode(JsonInstanceBinary, [{return_maps, false}]),
   jesse:validate( Schema
                 , JsonInstanceJsx
                 ).
@@ -97,7 +97,7 @@ add_schemata([]) ->
   ok;
 add_schemata([SchemaFile|Rest]) ->
   {ok, SchemaBin} = file:read_file(SchemaFile),
-  Schema0 = jsx:decode(SchemaBin),
+  Schema0 = jsx:decode(SchemaBin, [{return_maps, false}]),
   Schema = maybe_fill_schema_id(SchemaFile, Schema0),
   ok = jesse:add_schema(SchemaFile, Schema),
   add_schemata(Rest).

--- a/src/jesse_database.erl
+++ b/src/jesse_database.erl
@@ -318,7 +318,7 @@ add_file_uri(Key0) ->
   "file://" ++ File = Key,
   {ok, SchemaBin} = file:read_file(File),
   {ok, #file_info{mtime = Mtime}} = file:read_file_info(File),
-  Schema = jsx:decode(SchemaBin),
+  Schema = jsx:decode(SchemaBin, [{return_maps, false}]),
   SchemaInfos = [{Key, Mtime, Schema}],
   ValidationFun = fun jesse_lib:is_json_object/1,
   store_schemas(SchemaInfos, ValidationFun).
@@ -328,7 +328,7 @@ add_http_uri(Key0) ->
   Key = jesse_state:canonical_path(Key0, Key0),
   {ok, Response} = httpc:request(get, {Key, []}, [], [{body_format, binary}]),
   {{_Line, 200, _}, Headers, SchemaBin} = Response,
-  Schema = jsx:decode(SchemaBin),
+  Schema = jsx:decode(SchemaBin, [{return_maps, false}]),
   SchemaInfos = [{Key, get_http_mtime(Headers), Schema}],
   ValidationFun = fun jesse_lib:is_json_object/1,
   store_schemas(SchemaInfos, ValidationFun).

--- a/src/jesse_tests_util.erl
+++ b/src/jesse_tests_util.erl
@@ -52,7 +52,7 @@ get_tests(RelativeTestsDir, DefaultSchema, Config) ->
   TestFiles = filelib:wildcard(TestsDir ++ "/*.json"),
   lists:map( fun(TestFile) ->
                  {ok, Bin} = file:read_file(TestFile),
-                 Tests = jsx:decode(Bin),
+                 Tests = jsx:decode(Bin, [{return_maps, false}]),
                  Key = testfile_to_key(TestFile),
                  CaseConfig = {Tests, DefaultSchema},
                  {Key, CaseConfig}
@@ -139,4 +139,4 @@ get_path(Key, Schema) ->
 load_schema(URI) ->
   {ok, Response} = httpc:request(get, {URI, []}, [], [{body_format, binary}]),
   {{_Line, 200, _}, _Headers, Body} = Response,
-  jsx:decode(Body).
+  jsx:decode(Body, [{return_maps, false}]).


### PR DESCRIPTION
`jsx` was changed (in 3.0.0) in a way that breaks interface (namely option `return_maps` became _`true` by default_).

This pull request adapts `jesse` so that consumers of it, that are locking `jsx` at 3.0.0+, don't get affected by `jesse`'s internals.