### PR TITLE
Add new OTP versions to CI: 23.2, 23.3 and 24.0-rc3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
           - '22.3'
           - '23'
           - '23.1'
+          - '23.2'
+          - '23.3'
+          - '24.0-rc3'
     name: 'ci-erl:${{ matrix.otp_vsn }}'
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
as discussed in #103 