### PR TITLE
Add support for unicode properties in pattern, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,13 +274,24 @@ ErrorType}` where
 
 * pattern and patternProperty attributes:
 
-  jesse uses standard erlang module `re` for regexp matching, therefore there could be
-  some incompatible regular expressions in schemas you define.
+  jesse uses standard erlang module `re` for regexp matching, therefore there
+  could be some incompatible regular expressions in schemas you define.
 
-  From erlang docs: "re's matching algorithms are currently based on the PCRE library,
-  but not all of the PCRE library is interfaced"
+  From the [erlang docs](https://www.erlang.org/doc/man/re.html#description):
 
-  But most of common cases should work fine.
+  > The matching algorithms of the library are based on the PCRE library, but
+  > not all of the PCRE library is interfaced and some parts of the library go
+  > beyond what PCRE offers.
+
+  Most common cases should work fine. Note that jesse provides an application
+  environment setting, `re_options` (default: `[unicode, ucp]`), for customizing
+  its use of the `re` module. `ucp` provides the widest compatibility for
+  matching unicode code points beyond ISO Latin-1 in character classes like
+  `\w`, `\s`, and `\d`, but hurts performance. If maximum compatibility is not
+  required and performance is a significant concern, set `re_options` to
+  `[unicode]` instead. See notes on the `ucp` option at
+  [`re:compile/2`](https://www.erlang.org/doc/man/re.html#compile-2) for more
+  details.
 
 * internal references (id attribute) are NOT supported
 

--- a/src/jesse.app.src
+++ b/src/jesse.app.src
@@ -14,6 +14,8 @@
                    , jsx
                    , rfc3339
                    ]}
+  , {env, [ {re_options, [unicode, ucp]}
+          ]}
   , {licenses, [ "Apache 2.0"
                ]}
   , {links, [ {"Github", "https://github.com/for-GET/jesse"}

--- a/src/jesse_lib.erl
+++ b/src/jesse_lib.erl
@@ -28,6 +28,8 @@
         , is_array/1
         , is_json_object/1
         , is_null/1
+        , re_run/2
+        , re_options/0
         ]).
 
 %% Includes
@@ -86,3 +88,22 @@ is_null(null) ->
 is_null(_Value) ->
   false.
 
+%% @doc Run the RE against the subject using the `re_options' from the jesse
+%% application environment. `{capture, none}' is always used.
+-spec re_run( Subject :: iodata() | unicode:charlist()
+            , RE :: iodata() | unicode:charlist()
+            ) -> match
+               | nomatch.
+re_run(Subject, RE) ->
+  re:run(Subject, RE, [{capture, none} | re_options()]).
+
+%% @doc Returns the base re options from jesse environment which will be used
+%% when running client-provided patterns. By default, that is `[unicode, ucp]'
+%% for the fullest compatibility matching unicode code points beyond ISO Latin-1
+%% in character classes like `\w', `\s', and `\d'. Use only `[unicode]' instead
+%% (without `ucp`) for better performance at the expense of full non-ISO Latin-1
+%% compatibility in character classes. See also notes on the `ucp' option at
+%% [https://www.erlang.org/doc/man/re.html#compile-2 re:compile/2].
+-spec re_options() -> list().
+re_options() ->
+  application:get_env(jesse, re_options, [unicode, ucp]).

--- a/src/jesse_validator_draft3.erl
+++ b/src/jesse_validator_draft3.erl
@@ -409,7 +409,7 @@ check_pattern_properties(Value, PatternProperties, State) ->
 
 %% @private
 check_match({PropertyName, PropertyValue}, {Pattern, Schema}, State) ->
-  case re:run(PropertyName, Pattern, [{capture, none}, unicode]) of
+  case jesse_lib:re_run(PropertyName, Pattern) of
     match   ->
       check_value( PropertyName
                  , PropertyValue
@@ -496,7 +496,7 @@ get_additional_properties(Value, Properties, PatternProperties) ->
 %% @private
 filter_extra_names(Pattern, ExtraNames) ->
   Filter = fun(ExtraName) ->
-               case re:run(ExtraName, Pattern, [{capture, none}, unicode]) of
+               case jesse_lib:re_run(ExtraName, Pattern) of
                  match   -> false;
                  nomatch -> true
                end
@@ -785,7 +785,7 @@ check_unique_items(Value, true, State) ->
 %% specification from ECMA 262/Perl 5
 %% @private
 check_pattern(Value, Pattern, State) ->
-  case re:run(Value, Pattern, [{capture, none}, unicode]) of
+  case jesse_lib:re_run(Value, Pattern) of
     match   -> State;
     nomatch ->
       handle_data_invalid(?no_match, Value, State)

--- a/src/jesse_validator_draft4.erl
+++ b/src/jesse_validator_draft4.erl
@@ -416,7 +416,7 @@ check_pattern_properties(Value, PatternProperties, State) ->
 
 %% @private
 check_match({PropertyName, PropertyValue}, {Pattern, Schema}, State) ->
-  case re:run(PropertyName, Pattern, [{capture, none}, unicode]) of
+  case jesse_lib:re_run(PropertyName, Pattern) of
     match   ->
       check_value( PropertyName
                  , PropertyValue
@@ -497,7 +497,7 @@ get_additional_properties(Value, Properties, PatternProperties) ->
 %% @private
 filter_extra_names(Pattern, ExtraNames) ->
   Filter = fun(ExtraName) ->
-               case re:run(ExtraName, Pattern, [{capture, none}, unicode]) of
+               case jesse_lib:re_run(ExtraName, Pattern) of
                  match   -> false;
                  nomatch -> true
                end
@@ -868,7 +868,7 @@ check_unique_items(Value, true, State) ->
 %%   anchored.
 %% @private
 check_pattern(Value, Pattern, State) ->
-  case re:run(Value, Pattern, [{capture, none}, unicode]) of
+  case jesse_lib:re_run(Value, Pattern) of
     match   -> State;
     nomatch ->
       handle_data_invalid(?no_match, Value, State)
@@ -960,7 +960,7 @@ check_format(Value, _Format = <<"date-time">>, State) when is_binary(Value) ->
     false -> handle_data_invalid(?wrong_format, Value, State)
   end;
 check_format(Value, _Format = <<"email">>, State) when is_binary(Value) ->
-  case re:run(Value, <<"^[^@]+@[^@]+$">>, [{capture, none}, unicode]) of
+  case jesse_lib:re_run(Value, <<"^[^@]+@[^@]+$">>) of
     match   -> State;
     nomatch -> handle_data_invalid(?wrong_format, Value, State)
   end;

--- a/test/jesse_lib_tests.erl
+++ b/test/jesse_lib_tests.erl
@@ -1,0 +1,51 @@
+%% @author Nicholas Lundgaard <nalundgaard@gmail.com>
+
+%% @doc EUnit tests for jesse_lib.
+-module(jesse_lib_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+re_run_default_test_() ->
+  {setup,
+   fun() ->
+     application:load(jesse)
+   end,
+   fun(_) ->
+     application:unload(jesse)
+   end,
+   [
+    {"Support ISO Latin-1 letters in \w by default",
+     ?_assertEqual(match,
+                   jesse_lib:re_run(<<"föø"/utf8>>, "^\\w+$"))},
+    {"Support ISO Latin-1 numbers in \d by default",
+     ?_assertEqual(match,
+                   jesse_lib:re_run(<<"123"/utf8>>, "^\\d+$"))},
+    {"Support beyond ISO Latin-1 letters in \w by default",
+     ?_assertEqual(match,
+                   jesse_lib:re_run(<<"fōô"/utf8>>, "^\\w+$"))},
+    {"Support beyond ISO Latin-1 numbers in \d by default",
+     ?_assertEqual(match,
+                   jesse_lib:re_run(<<"3๓३"/utf8>>, "^\\d+$"))}
+   ]}.
+
+re_run_no_ucp_test_() ->
+  {setup,
+   fun() ->
+     application:load(jesse),
+     application:set_env(jesse, re_options, [unicode])
+   end,
+   fun(_) -> application:unload(jesse) end,
+   [
+    {"Support ISO Latin-1 letters in \w without 'ucp'",
+     ?_assertEqual(match,
+                   jesse_lib:re_run(<<"föø"/utf8>>, "^\\w+$"))},
+    {"Support ISO Latin-1 numbers in \d  without 'ucp'",
+     ?_assertEqual(match,
+                   jesse_lib:re_run(<<"123"/utf8>>, "^\\d+$"))},
+    {"Do not support beyond ISO Latin-1 letters in \w without 'ucp'",
+     ?_assertEqual(nomatch,
+                   jesse_lib:re_run(<<"fōô"/utf8>>, "^\\w+$"))},
+    {"Do not support beyond ISO Latin-1 numbers in \d without 'ucp'",
+     ?_assertEqual(nomatch,
+                   jesse_lib:re_run(<<"3๓३"/utf8>>, "^\\d+$"))}
+   ]}.


### PR DESCRIPTION
Resolves https://github.com/for-GET/jesse/issues/104.

Adds support for unicode properties "pattern" and "patternProperties" by adding `re_options` to the `jesse` application environment and making all uses of `re:run/2` consult it. This effectively changes the previously hard-coded `unicode` option to `ucp`, but allows restoring the previous behavior (for better performance) by setting  `re_options` to `[unicode]` instead of `[ucp]`.