### PR TITLE
Fix crash when schema containing reference is `map()`

### DIFF
--- a/src/jesse_state.erl
+++ b/src/jesse_state.erl
@@ -182,7 +182,11 @@ set_current_schema(#state{id = Id} = State, NewSchema0) ->
         %% Instead of just removing all the other fields, we put schema as
         %% 1st element, so, only `ref' will be validated, while other fields
         %% (say, `definitions') may still be referenced.
-        [{?REF, Ref} | lists:keydelete(?REF, 1, NewSchema0)]
+        ListSchema = case is_map(NewSchema0) of
+                       true -> maps:to_list(NewSchema0);
+                       false -> NewSchema0
+                     end,
+        [{?REF, Ref} | lists:keydelete(?REF, 1, ListSchema)]
     end,
   NewSchemaId = jesse_json_path:value(?ID, NewSchema, undefined),
   NewId = combine_id(Id, NewSchemaId),

--- a/test/jesse_schema_validator_tests.erl
+++ b/test/jesse_schema_validator_tests.erl
@@ -392,5 +392,19 @@ map_data_test_draft(URI) ->
                                               , [{allowed_errors, infinity}]
                                               )).
 
+%% Make sure references work with schemas as maps
+map_schema_references_test() ->
+  Schema = #{<<"definitions">> =>
+               #{<<"a">> => #{<<"type">> => <<"object">>}},
+             <<"type">> => <<"object">>,
+             <<"properties">> =>
+               #{<<"prop">> => #{<<"$ref">> => <<"#/definitions/a">>}}},
+  Json = #{<<"prop">> => #{}},
+  ?assertMatch(
+     {ok, _},
+     jesse_schema_validator:validate(
+       Schema, Json,
+       [{default_schema_ver, <<"http://json-schema.org/draft-04/schema#">>}])).
+
 -endif.
 -endif.


### PR DESCRIPTION
Fixes issue introduced in https://github.com/for-GET/jesse/pull/109#discussion_r765319152