### PR TITLE
Use conversion to sets to check uniqueItems (performance improvement)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@ else
 REBAR3 ?= $(shell command -v rebar3 2>/dev/null || echo "./rebar3.OTP$(OTP_RELEASE)")
 endif
 
+REBAR_CONFIG = rebar.OTP$(OTP_RELEASE).config
+
 SRCS := $(wildcard src/* include/* rebar.config)
 
 .PHONY: all
@@ -21,7 +23,7 @@ all: ebin/jesse.app bin/jesse
 
 .PHONY: clean
 clean:
-	$(REBAR3) clean
+	REBAR_CONFIG=$(REBAR_CONFIG) $(REBAR3) clean
 
 .PHONY: distclean
 distclean:
@@ -41,7 +43,7 @@ clean-tests:
 
 .PHONY: docs
 docs:
-	$(REBAR3) edoc
+	REBAR_CONFIG=$(REBAR_CONFIG) $(REBAR3) edoc
 
 # Compile
 
@@ -53,12 +55,12 @@ ebin/jesse.app: compile
 
 .PHONY: escript
 escript: ebin/jesse.app
-	$(REBAR3) escriptize
+	REBAR_CONFIG=$(REBAR_CONFIG) $(REBAR3) escriptize
 	./_build/default/bin/jesse --help
 
 .PHONY: compile
 compile: $(SRCS)
-	$(REBAR3) compile
+	REBAR_CONFIG=$(REBAR_CONFIG) $(REBAR3) compile
 
 # Tests
 
@@ -69,38 +71,42 @@ test/JSON-Schema-Test-Suite/tests:
 .PHONY: test
 # Would be nice to include elvis to test, but it fails on OTP-18
 # test: elvis
-test: eunit ct xref dialyzer cover
+test: eunit ct xref dialyzer proper cover
 
 .PHONY: elvis
 elvis:
-	$(REBAR3) lint
+	REBAR_CONFIG=$(REBAR_CONFIG) $(REBAR3) lint
 
 .PHONY: eunit
 eunit:
 	@ $(MAKE) clean-tests
-	$(REBAR3) eunit
+	REBAR_CONFIG=$(REBAR_CONFIG) $(REBAR3) eunit
 
 .PHONY: ct
 ct: test/JSON-Schema-Test-Suite/tests
 	@ $(MAKE) clean-tests
-	TEST_DIR=_build/default/test/lib/jesse/test $(REBAR3) ct
+	TEST_DIR=_build/default/test/lib/jesse/test REBAR_CONFIG=$(REBAR_CONFIG) $(REBAR3) ct
 
 .PHONY: xref
 xref:
-	$(REBAR3) xref
+	REBAR_CONFIG=$(REBAR_CONFIG) $(REBAR3) xref
 
 .PHONY: dialyzer
 dialyzer:
-	$(REBAR3) dialyzer
+	REBAR_CONFIG=$(REBAR_CONFIG) $(REBAR3) dialyzer
 
 .PHONY: cover
 cover:
 	@ $(MAKE) clean-tests
-	$(REBAR3) cover -v
+	REBAR_CONFIG=$(REBAR_CONFIG) $(REBAR3) cover -v
+
+.PHONY: proper
+proper:
+	REBAR_CONFIG=$(REBAR_CONFIG) $(REBAR3) proper
 
 .PHONY: publish
 publish: docs
-	$(REBAR3) hex publish -r hexpm --yes
+	REBAR_CONFIG=$(REBAR_CONFIG) $(REBAR3) hex publish -r hexpm --yes
 
 .PHONY: rebar3.OTP18
 rebar3.OTP18:

--- a/rebar.OTP18.config
+++ b/rebar.OTP18.config
@@ -1,5 +1,5 @@
 %%-*- mode: erlang -*-
-{profiles, [{test, [{deps, [{ proper, "1.4.0"}]}]}]}.
+{profiles, [{test, [{deps, [{ proper, "1.2.0"}]}]}]}.
 {erl_opts, [ {platform_define, "^R[0-9]+", erlang_deprecated_types}
              %% , warn_export_all
            , warn_export_vars

--- a/rebar.OTP19.config
+++ b/rebar.OTP19.config
@@ -1,0 +1,1 @@
+rebar.OTP18.config

--- a/rebar.OTP20.config
+++ b/rebar.OTP20.config
@@ -1,0 +1,1 @@
+rebar.config

--- a/rebar.OTP21.config
+++ b/rebar.OTP21.config
@@ -1,0 +1,1 @@
+rebar.OTP20.config

--- a/rebar.OTP22.config
+++ b/rebar.OTP22.config
@@ -1,0 +1,1 @@
+rebar.OTP20.config

--- a/rebar.OTP23.config
+++ b/rebar.OTP23.config
@@ -1,0 +1,1 @@
+rebar.OTP20.config

--- a/rebar.OTP24.config
+++ b/rebar.OTP24.config
@@ -1,0 +1,1 @@
+rebar.OTP20.config

--- a/src/jesse_lib.erl
+++ b/src/jesse_lib.erl
@@ -30,6 +30,8 @@
         , is_null/1
         , re_run/2
         , re_options/0
+        , normalize_and_sort/1
+        , is_equal/2
         ]).
 
 %% Includes
@@ -107,3 +109,135 @@ re_run(Subject, RE) ->
 -spec re_options() -> list().
 re_options() ->
   application:get_env(jesse, re_options, [unicode, ucp]).
+
+%% @doc Returns a JSON object in which all lists for
+%% which order is not relevant will be sorted.  In this way, there
+%% will be no differences between objects that contain one of those
+%% lists with the same elements but in different order.  Lists for
+%% which order is relevant, e.g. JSON arrays, keep their original
+%% order and will be considered diffferent if the order is different.
+-spec normalize_and_sort(Value :: any()) -> any().
+normalize_and_sort(Value) ->
+  normalize_and_sort_check_object(Value).
+
+%% This code would look much better if we could use
+%% normalize_and_sort_check_object as a guard expression, but that is not
+%% possible.  So we need to check in every recurssion step, first if the
+%% Value is a JSON object with properties, and in that case call a
+%% different function for these values.
+%% @private
+-spec normalize_and_sort_check_object(Value :: any()) -> any().
+normalize_and_sort_check_object(Value) ->
+  case jesse_lib:is_json_object(Value) of
+    true -> normalize_and_sort_object(Value);
+    false -> normalize_and_sort_non_object(Value)
+  end.
+
+%% This function covers the recursion over:
+%% - properties within an object, seen as tuples. In that case, we run
+%%   the normalization/ordering over the values of these properties.
+%% - JSON arrays, seen as lists. In that case, we keep the order of
+%%   the list and run the normalization/ordering over each of the values
+%%   in the list.
+%% - Basic JSON types. In that case, we just return the value.
+%% @private
+-spec normalize_and_sort_non_object(Value :: any()) -> any().
+normalize_and_sort_non_object({Key, Val}) ->
+  {Key, normalize_and_sort_check_object(Val)};
+normalize_and_sort_non_object(Value) when is_list(Value) ->
+  [normalize_and_sort_check_object(X) || X <- Value];
+normalize_and_sort_non_object(Value) when is_number(Value) ->
+  case Value == float(Value) of
+    true -> float(Value);
+    false -> Value
+  end;
+normalize_and_sort_non_object(Value) ->
+  Value.
+
+%% This function runs the normalization/ordering over the properties
+%% of a JSON object. If the object is not formatted as a list (e.g. a
+%% map), it is unwrapped into a list. Then the list of properties is
+%% order so that its original odering is not relevant, and we run
+%% the normalization/ordering through each of the properties.
+%% @private
+-spec normalize_and_sort_object(Value :: any()) -> any().
+normalize_and_sort_object(Value) when is_map(Value)->
+  maps:map(fun (_K, V) -> normalize_and_sort_check_object(V) end, Value);
+normalize_and_sort_object(Value) ->
+  normalize_and_sort_object(
+    maps:from_list(
+      jesse_json_path:unwrap_value(Value))).
+
+%%=============================================================================
+%% @doc Returns `true' if given values (instance) are equal, otherwise `false'
+%% is returned.
+%%
+%% Two instance are consider equal if they are both of the same type
+%% and:
+%% <ul>
+%%   <li>are null; or</li>
+%%
+%%   <li>are booleans/numbers/strings and have the same value; or</li>
+%%
+%%   <li>are arrays, contains the same number of items, and each item in
+%%       the array is equal to the corresponding item in the other array;
+%%       or</li>
+%%
+%%   <li>are objects, contains the same property names, and each property
+%%       in the object is equal to the corresponding property in the other
+%%       object.</li>
+%% </ul>
+-spec is_equal(Value1 :: any(), Value2 :: any()) -> boolean().
+is_equal(Value1, Value2) ->
+  case jesse_lib:is_json_object(Value1)
+    andalso jesse_lib:is_json_object(Value2) of
+    true  -> compare_objects(Value1, Value2);
+    false -> case is_list(Value1) andalso is_list(Value2) of
+               true  -> compare_lists(Value1, Value2);
+               false -> Value1 == Value2
+             end
+  end.
+
+%% @private
+compare_lists(Value1, Value2) ->
+  case length(Value1) =:= length(Value2) of
+    true  -> compare_elements(Value1, Value2);
+    false -> false
+  end.
+
+%% @private
+compare_elements(Value1, Value2) ->
+  lists:all( fun({Element1, Element2}) ->
+                 is_equal(Element1, Element2)
+             end
+           , lists:zip(Value1, Value2)
+           ).
+
+%% @private
+compare_objects(Value1, Value2) ->
+  case length(unwrap(Value1)) =:= length(unwrap(Value2)) of
+    true  -> compare_properties(Value1, Value2);
+    false -> false
+  end.
+
+%% @private
+compare_properties(Value1, Value2) ->
+  lists:all( fun({PropertyName1, PropertyValue1}) ->
+                 case get_value(PropertyName1, Value2) of
+                   ?not_found     -> false;
+                   PropertyValue2 -> is_equal(PropertyValue1,
+                                              PropertyValue2)
+                 end
+             end
+           , unwrap(Value1)
+           ).
+
+%%=============================================================================
+%% Wrappers
+%% @private
+get_value(Key, Schema) ->
+  jesse_json_path:value(Key, Schema, ?not_found).
+
+%% @private
+unwrap(Value) ->
+  jesse_json_path:unwrap_value(Value).

--- a/src/jesse_schema_validator.hrl
+++ b/src/jesse_schema_validator.hrl
@@ -28,6 +28,20 @@
 -define(IF_MAPS(Exp), Exp).
 -endif.
 
+%% Use optimization for sets if available
+-ifdef(OTP_RELEASE).
+  -if(?OTP_RELEASE >= 24).
+  %% OTP 24 or higher
+    -define(SET_FROM_LIST(List), sets:from_list(List, [{version, 2}])).
+  -else.
+  %% OTP 23, 22 or 21.
+    -define(SET_FROM_LIST(List), sets:from_list(List)).
+  -endif.
+-else.
+  %% OTP 20 or lower.
+  -define(SET_FROM_LIST(List), sets:from_list(List)).
+-endif.
+
 %% Constant definitions for Json schema keywords
 -define(SCHEMA,               <<"$schema">>).
 -define(TYPE,                 <<"type">>).

--- a/src/jesse_validator_draft4.erl
+++ b/src/jesse_validator_draft4.erl
@@ -825,29 +825,45 @@ check_unique_items(_, false, State) ->
   State;
 check_unique_items([], true, State) ->
   State;
+check_unique_items([_], true, State) ->
+  State;
 check_unique_items(Value, true, State) ->
   try
-    lists:foldl( fun(_Item, []) ->
-                     ok;
-                    (Item, RestItems) ->
-                     lists:foreach( fun(ItemFromRest) ->
-                                        case is_equal(Item, ItemFromRest) of
-                                          true  ->
-                                            throw({?not_unique, Item});
-                                          false -> ok
-                                        end
-                                    end
-                                  , RestItems
-                                  ),
-                     tl(RestItems)
-                 end
-               , tl(Value)
-               , Value
-               ),
-    State
+%% First we do an efficient check for duplicates: convert the list to a set
+%% and if there are no duplicates, the set and the list have the same length
+%% In order to avoid differences for lists in which order is not relevant
+%% (e.g. JSON properties of an object maybe represented as a proplist), these
+%% lists for which order is not relevant are sorted (objects are normalized).
+%% If the first efficient check fails, then we search for the items that are
+%% duplicated with a less efficient check (that will very seldom be executed).
+    NormalizedValue = jesse_lib:normalize_and_sort(Value),
+    NoDuplicates = ?SET_FROM_LIST(NormalizedValue),
+    case sets:size(NoDuplicates) == length(Value) of
+      true -> State;
+      false ->
+        lists:foldl( fun compare_rest_items/2
+                   , tl(Value)
+                   , Value
+                   ),
+        State
+    end
   catch
     throw:ErrorInfo -> handle_data_invalid(ErrorInfo, Value, State)
   end.
+
+%% @private
+compare_rest_items(_Item, []) ->
+  ok;
+compare_rest_items(Item, RestItems) ->
+  lists:foreach( fun(ItemFromRest) ->
+                     case jesse_lib:is_equal(Item, ItemFromRest) of
+                       true  -> throw({?not_unique, Item});
+                       false -> ok
+                     end
+                 end
+               , RestItems
+               ),
+  tl(RestItems).
 
 %% @doc 5.2.3. pattern
 %%
@@ -936,7 +952,7 @@ check_max_length(Value, MaxLength, State) ->
 %% @private
 check_enum(Value, Enum, State) ->
   IsValid = lists:any( fun(ExpectedValue) ->
-                           is_equal(Value, ExpectedValue)
+                           jesse_lib:is_equal(Value, ExpectedValue)
                        end
                      , Enum
                      ),
@@ -1265,69 +1281,6 @@ resolve_ref(Reference, State) ->
 
 undo_resolve_ref(State, OriginalState) ->
   jesse_state:undo_resolve_ref(State, OriginalState).
-
-%%=============================================================================
-%% @doc Returns `true' if given values (instance) are equal, otherwise `false'
-%% is returned.
-%%
-%% Two instance are consider equal if they are both of the same type
-%% and:
-%% <ul>
-%%   <li>are null; or</li>
-%%
-%%   <li>are booleans/numbers/strings and have the same value; or</li>
-%%
-%%   <li>are arrays, contains the same number of items, and each item in
-%%       the array is equal to the corresponding item in the other array;
-%%       or</li>
-%%
-%%   <li>are objects, contains the same property names, and each property
-%%       in the object is equal to the corresponding property in the other
-%%       object.</li>
-%% </ul>
-%% @private
-is_equal(Value1, Value2) ->
-  case jesse_lib:is_json_object(Value1)
-    andalso jesse_lib:is_json_object(Value2) of
-    true  -> compare_objects(Value1, Value2);
-    false -> case is_list(Value1) andalso is_list(Value2) of
-               true  -> compare_lists(Value1, Value2);
-               false -> Value1 == Value2
-             end
-  end.
-
-%% @private
-compare_lists(Value1, Value2) ->
-  case length(Value1) =:= length(Value2) of
-    true  -> compare_elements(Value1, Value2);
-    false -> false
-  end.
-
-%% @private
-compare_elements(Value1, Value2) ->
-  lists:all( fun({Element1, Element2}) ->
-                 is_equal(Element1, Element2)
-             end
-           , lists:zip(Value1, Value2)
-           ).
-
-%% @private
-compare_objects(Value1, Value2) ->
-  case length(unwrap(Value1)) =:= length(unwrap(Value2)) of
-    true  -> compare_properties(Value1, Value2);
-    false -> false
-  end.
-
-%% @private
-compare_properties(Value1, Value2) ->
-  lists:all( fun({PropertyName1, PropertyValue1}) ->
-                 case get_value(PropertyName1, Value2) of
-                   ?not_found     -> false;
-                   PropertyValue2 -> is_equal(PropertyValue1, PropertyValue2)
-                 end
-             end
-           , unwrap(Value1)
-           ).
 
 %%=============================================================================
 %% Wrappers

--- a/test/jesse_tests_draft3_SUITE.erl
+++ b/test/jesse_tests_draft3_SUITE.erl
@@ -33,6 +33,7 @@
                        ]).
 
 -include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
 
 -import(jesse_tests_util, [ get_tests/3
                           , do_test/2
@@ -145,3 +146,6 @@ remoteRefExtra(Config) ->
 
 unicodePatternProperties(Config) ->
   do_test("unicodePatternProperties", Config).
+
+uniqueItemsExtra(Config) ->
+  do_test("uniqueItemsExtra", Config).

--- a/test/jesse_tests_draft3_SUITE_data/extra/uniqueItemsExtra.json
+++ b/test/jesse_tests_draft3_SUITE_data/extra/uniqueItemsExtra.json
@@ -1,0 +1,23 @@
+[
+    {
+        "description": "uniqueItems extra validation",
+        "schema": {"uniqueItems": true},
+        "tests": [
+            {
+                "description": "big integers are compared correctly",
+                "data": [123456789012345678901234567890, 123456789012345678901234567891],
+                "valid": true
+            },
+            {
+                "description": "compare all elements within object, extra",
+                "data": [{"a": {"a": 1, "b": 2}}, {"a": {"b":2, "a": 1}}],
+                "valid": false
+            },
+            {
+                "description": "numbers are unique if mathematically unequal, extra",
+                "data": [1.0, 1],
+                "valid": false
+            }
+        ]
+    }
+]

--- a/test/jesse_tests_draft4_SUITE.erl
+++ b/test/jesse_tests_draft4_SUITE.erl
@@ -33,6 +33,7 @@
                        ]).
 
 -include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
 
 -import(jesse_tests_util, [ get_tests/3
                           , do_test/2
@@ -188,3 +189,6 @@ ipv4Format(Config) ->
 
 ipv6Format(Config) ->
   do_test("ipv6Format", Config).
+
+uniqueItemsExtra(Config) ->
+  do_test("uniqueItemsExtra", Config).

--- a/test/jesse_tests_draft4_SUITE_data/extra/uniqueItemsExtra.json
+++ b/test/jesse_tests_draft4_SUITE_data/extra/uniqueItemsExtra.json
@@ -1,0 +1,23 @@
+[
+    {
+        "description": "uniqueItems extra validation",
+        "schema": {"uniqueItems": true},
+        "tests": [
+            {
+                "description": "big integers are compared correctly",
+                "data": [123456789012345678901234567890, 123456789012345678901234567891],
+                "valid": true
+            },
+            {
+                "description": "compare all elements within object, extra",
+                "data": [{"a": {"a": 1, "b": 2}}, {"a": {"b":2, "a": 1}}],
+                "valid": false
+            },
+            {
+                "description": "numbers are unique if mathematically unequal, extra",
+                "data": [1.0, 1],
+                "valid": false
+            }
+        ]
+    }
+]

--- a/test/prop_get_equal.erl
+++ b/test/prop_get_equal.erl
@@ -1,0 +1,24 @@
+-module(prop_get_equal).
+-include_lib("proper/include/proper.hrl").
+
+%%%%%%%%%%%%%%%%%%
+%%% Properties %%%
+%%%%%%%%%%%%%%%%%%
+prop_get_equal() ->
+    ?FORALL(Type, resize(4, json_list()),
+        begin
+            boolean(Type)
+        end).
+
+%%%%%%%%%%%%%%%
+%%% Helpers %%%
+%%%%%%%%%%%%%%%
+boolean(Type) ->
+    jesse_lib:is_equal(
+        jesse_lib:normalize_and_sort(Type),
+        Type).
+
+%%%%%%%%%%%%%%%%%%
+%%% Generators %%%
+%%%%%%%%%%%%%%%%%%
+json_list() -> list(proper_json:json()).

--- a/test/proper_json.erl
+++ b/test/proper_json.erl
@@ -1,0 +1,49 @@
+-module(proper_json).
+
+-export([json/0, json/1]).
+
+-include_lib("proper/include/proper.hrl").
+
+json() ->
+  ?SIZED(Size, json(Size)).
+
+
+json(0) ->
+  j_literal();
+json(Size) ->
+  ?LAZY(proper_types:frequency(
+          [{60, j_literal()},
+           {20, j_array(Size)},
+           {20, j_object(Size)}])).
+
+j_object(0) ->
+  #{};
+j_object(Size) ->
+  ?LET(KV,
+       proper_types:list({j_string(), json(Size div 2)}),
+       maps:from_list(KV)).
+
+j_array(0) ->
+  [];
+j_array(Size) ->
+  proper_types:list(json(Size div 2)).
+
+j_string() ->
+  %% proper_unicode:utf8().
+  ?LET(Str,
+       proper_types:non_empty(chars()),
+       list_to_binary(Str)).
+
+j_literal() ->
+    proper_types:oneof(
+      [j_string(),
+       proper_types:integer(),
+       proper_types:float(),
+       proper_types:boolean(),
+       null]).
+
+chars() ->
+  proper_types:list(
+    proper_types:oneof(lists:seq($a, $z) ++
+                         lists:seq($A, $Z) ++
+                         lists:seq($0, $9))).


### PR DESCRIPTION
This pull request addresses https://github.com/for-GET/jesse/issues/115 

The current implementation of the check for uniqueItems condition in a JSON array seems to be inefficient, with an implementation that has approximately O(n^2) complexity on the number of elements in the array.

This proposal is to change the implementation by using a conversion to a set of the array under uniqueItems condition, and in this way eliminating duplicates efficiently. In order to do this, the format for JSON objects within the array is normalized to Erlang maps.

Implementation of normalization and is_equal is moved to jesse_lib.