### PR TITLE
Use `== 0.0` to check if the value is zero instead of pattern matching to fix warnings in the OTP master

### DIFF
--- a/src/jesse_validator_draft3.erl
+++ b/src/jesse_validator_draft3.erl
@@ -861,8 +861,8 @@ check_divisible_by(Value, 0, State) ->
   handle_data_invalid(?not_divisible, Value, State);
 check_divisible_by(Value, DivisibleBy, State) ->
   Result = (Value / DivisibleBy - trunc(Value / DivisibleBy)) * DivisibleBy,
-  case Result of
-    0.0 ->
+  case Result == 0.0 of
+    true ->
       State;
     _   ->
       handle_data_invalid(?not_divisible, Value, State)

--- a/src/jesse_validator_draft4.erl
+++ b/src/jesse_validator_draft4.erl
@@ -1015,8 +1015,8 @@ check_format(_Value, _Format, State) ->
 check_multiple_of(Value, MultipleOf, State)
   when is_number(MultipleOf), MultipleOf > 0 ->
   Result = (Value / MultipleOf - trunc(Value / MultipleOf)) * MultipleOf,
-  case Result of
-    0.0 ->
+  case Result == 0.0 of
+    true ->
       State;
     _   ->
       handle_data_invalid(?not_multiple_of, Value, State)

--- a/src/jesse_validator_draft6.erl
+++ b/src/jesse_validator_draft6.erl
@@ -993,8 +993,8 @@ uri_reference(_Value, State) ->
 %% @private
 check_multiple_of(Value, MultipleOf, State)
   when is_number(MultipleOf), MultipleOf > 0 ->
-  try (Value / MultipleOf - trunc(Value / MultipleOf)) * MultipleOf of
-    0.0 ->
+  try (Value / MultipleOf - trunc(Value / MultipleOf)) * MultipleOf == 0.0 of
+    true ->
       State;
     _   ->
       handle_data_invalid(?not_multiple_of, Value, State)


### PR DESCRIPTION
Thank you for creating and maintaining this library.
I have discovered an issue whereby when compiling this library using [the OTP master branch](https://github.com/erlang/otp/commit/64d86675b6f87fd3671a415f84a4a61cc85c24cf), the compiler emits the following warning.

```console
$ rebar3 compile
===> Verifying dependencies...
===> Analyzing applications...
===> Compiling jesse
===> Compiling src/jesse_validator_draft4.erl failed
src/jesse_validator_draft4.erl:1019:5: matching on the float 0.0 will no longer also match -0.0 in OTP 27. If you specifically intend to match 0.0 alone, write +0.0 instead.
```

This PR fixes the warning.