### PR TITLE
jesse: fix handling of -0.0 for OTP-26.1/27.0

### DIFF
--- a/src/jesse_validator_draft3.erl
+++ b/src/jesse_validator_draft3.erl
@@ -862,7 +862,7 @@ check_divisible_by(Value, 0, State) ->
 check_divisible_by(Value, DivisibleBy, State) ->
   Result = (Value / DivisibleBy - trunc(Value / DivisibleBy)) * DivisibleBy,
   case Result of
-    0.0 ->
+    _ when Result == 0.0 ->
       State;
     _   ->
       handle_data_invalid(?not_divisible, Value, State)

--- a/src/jesse_validator_draft4.erl
+++ b/src/jesse_validator_draft4.erl
@@ -1016,7 +1016,7 @@ check_multiple_of(Value, MultipleOf, State)
   when is_number(MultipleOf), MultipleOf > 0 ->
   Result = (Value / MultipleOf - trunc(Value / MultipleOf)) * MultipleOf,
   case Result of
-    0.0 ->
+    _ when Result == 0.0 ->
       State;
     _   ->
       handle_data_invalid(?not_multiple_of, Value, State)

--- a/src/jesse_validator_draft6.erl
+++ b/src/jesse_validator_draft6.erl
@@ -994,7 +994,7 @@ uri_reference(_Value, State) ->
 check_multiple_of(Value, MultipleOf, State)
   when is_number(MultipleOf), MultipleOf > 0 ->
   try (Value / MultipleOf - trunc(Value / MultipleOf)) * MultipleOf of
-    0.0 ->
+    Num when Num == 0.0 ->
       State;
     _   ->
       handle_data_invalid(?not_multiple_of, Value, State)


### PR DESCRIPTION
Matching of floating-point zeroes will change in OTP-27 so that -0.0 will no longer match a non-negative 0.0. OTP-26.1 warns about such constructs, which in jesse results in:

===> Compiling src/jesse_validator_draft3.erl failed src/jesse_validator_draft3.erl:865:5: matching on the float 0.0 will no longer also match -0.0 in OTP 27. If you specifically intend to match 0.0 alone, write +0.0 instead.

===> Compiling src/jesse_validator_draft4.erl failed src/jesse_validator_draft4.erl:1019:5: matching on the float 0.0 will no longer also match -0.0 in OTP 27. If you specifically intend to match 0.0 alone, write +0.0 instead.

===> Compiling src/jesse_validator_draft6.erl failed src/jesse_validator_draft6.erl:997:5: matching on the float 0.0 will no longer also match -0.0 in OTP 27. If you specifically intend to match 0.0 alone, write +0.0 instead.

Fixed by switching from matches to numerical comparisons.