### PR TITLE
pass verify_none to httpc:request

### DIFF
--- a/src/jesse_database.erl
+++ b/src/jesse_database.erl
@@ -315,7 +315,8 @@ add_file_uri(Key0) ->
 %% @private
 add_http_uri(Key0) ->
   Key = jesse_state:canonical_path(Key0, Key0),
-  {ok, Response} = httpc:request(get, {Key, []}, [], [{body_format, binary}]),
+  HttpOptions = [{ssl, [{verify, verify_none}]}],
+  {ok, Response} = httpc:request(get, {Key, []}, HttpOptions, [{body_format, binary}]),
   {{_Line, 200, _}, Headers, SchemaBin} = Response,
   Schema = jsx:decode(SchemaBin, [{return_maps, false}]),
   SchemaInfos = [{Key, get_http_mtime(Headers), Schema}],

--- a/src/jesse_tests_util.erl
+++ b/src/jesse_tests_util.erl
@@ -147,6 +147,7 @@ get_path(Key, Schema) ->
   jesse_json_path:path(Key, Schema).
 
 load_schema(URI) ->
-  {ok, Response} = httpc:request(get, {URI, []}, [], [{body_format, binary}]),
+  HttpOptions = [{ssl, [{verify, verify_none}]}],
+  {ok, Response} = httpc:request(get, {URI, []}, HttpOptions, [{body_format, binary}]),
   {{_Line, 200, _}, _Headers, Body} = Response,
   jsx:decode(Body, [{return_maps, false}]).


### PR DESCRIPTION
The `ssl` changes in OTP-26 mean that any code that doesn't specify `verify_none` will default to `verify_peer,` and unless certs are passed in you get hard errors. This also affects `httpc:request`. Update uses of the latter to explicitly pass in `verify_none`.