### PR TITLE
Remove dependencies if not needed

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 %%-*- mode: erlang -*-
-{profiles, [{test, [{deps, [{ proper, "1.4.0"}]}]}]}.
+{profiles, [{test, [{deps, [{jsx, "3.1.0"}, {proper, "1.4.0"}]}]}]}.
 {erl_opts, [ {platform_define, "^R[0-9]+", erlang_deprecated_types}
              %% , warn_export_all
            , warn_export_vars
@@ -18,10 +18,6 @@
               , undefined_function_calls
               , deprecated_function_calls
               ]}.
-{ deps
-, [ {jsx, "3.1.0"}
-  ]}.
-
 { project_plugins
 , [ {rebar3_lint, "3.2.6"}
   , {rebar3_proper, "0.12.1"}

--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 %%-*- mode: erlang -*-
-{profiles, [{test, [{deps, [{jsx, "3.1.0"}, {proper, "1.4.0"}]}]}]}.
+{profiles, [{test, [{deps, [{jsx, "3.1.0"}, {rfc3339, "0.9.0"}, {proper, "1.4.0"}]}]}]}.
 {erl_opts, [ {platform_define, "^R[0-9]+", erlang_deprecated_types}
              %% , warn_export_all
            , warn_export_vars

--- a/rebar.config
+++ b/rebar.config
@@ -20,7 +20,6 @@
               ]}.
 { deps
 , [ {jsx, "3.1.0"}
-  , {rfc3339, "0.9.0"}
   ]}.
 
 { project_plugins

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,0 +1,12 @@
+{Deps0, Config0} = case lists:keytake(deps, 1, CONFIG) of
+                       false -> {[], CONFIG};
+                       {value, {deps, D}, Cfg} -> {D, Cfg}
+                   end,
+
+Deps = case list_to_integer(erlang:system_info(otp_release)) of
+           N when N >= 21 ->
+               [];
+           _ ->
+               [{rfc3339, "0.9.0"}]
+       end,
+[{deps, Deps ++ Deps0} | Config0].

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -4,9 +4,12 @@
                    end,
 
 Deps = case list_to_integer(erlang:system_info(otp_release)) of
-           N when N >= 21 ->
+           N when N >= 27 ->
                [];
+           N when N >= 21 ->
+               [{jsx, "3.1.0"}];
            _ ->
-               [{rfc3339, "0.9.0"}]
+               [{jsx, "3.1.0"}, {rfc3339, "0.9.0"}]
        end,
+
 [{deps, Deps ++ Deps0} | Config0].

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -5,11 +5,11 @@
 
 Deps = case list_to_integer(erlang:system_info(otp_release)) of
            N when N >= 27 ->
-               [];
+               Deps0;
            N when N >= 21 ->
-               [{jsx, "3.1.0"}];
+               [{jsx, "3.1.0"} | Deps0];
            _ ->
-               [{jsx, "3.1.0"}, {rfc3339, "0.9.0"}]
+               [{jsx, "3.1.0"}, {rfc3339, "0.9.0"} | Deps0]
        end,
 
-[{deps, Deps ++ Deps0} | Config0].
+[{deps, Deps} | Config0].

--- a/src/jesse.app.src
+++ b/src/jesse.app.src
@@ -11,7 +11,6 @@
                    , public_key
                    , ssl
                    , inets
-                   , jsx
                    ]}
   , {env, [ {re_options, [unicode, ucp]}
           ]}

--- a/src/jesse.app.src
+++ b/src/jesse.app.src
@@ -12,7 +12,6 @@
                    , ssl
                    , inets
                    , jsx
-                   , rfc3339
                    ]}
   , {env, [ {re_options, [unicode, ucp]}
           ]}

--- a/src/jesse.app.src.script
+++ b/src/jesse.app.src.script
@@ -1,0 +1,19 @@
+[{application, jesse, Config}] = CONFIG,
+
+{Apps0, Config0} = case lists:keytake(applications, 1, Config) of
+                       false ->
+                           {[], CONFIG};
+                       {value, {applications, A}, Cfg} ->
+                           {A, Cfg}
+                   end,
+
+Apps = case list_to_integer(erlang:system_info(otp_release)) of
+           N when N >= 27 ->
+               Apps0;
+           N when N >= 21 ->
+               [jsx | Apps0];
+           _ ->
+               [jsx, rfc3339 | Apps0]
+       end,
+
+[{application, jesse, [{applications, Apps} | Config]}].

--- a/src/jesse_cli.erl
+++ b/src/jesse_cli.erl
@@ -75,7 +75,7 @@ run(Options, [Schema|_] = Schemata, [JsonInstance|JsonInstances]) ->
     undefined ->
       io:fwrite("~p\n\n", [Result]);
     true ->
-      io:fwrite("~s\n\n", [jsx:encode(Result)])
+      io:fwrite("~s\n\n", [?JSON:encode(Result)])
   end,
   case JesseResult of
     {ok, _} ->
@@ -90,7 +90,7 @@ jesse_run(JsonInstance, Schema, Schemata) ->
   {ok, _} = application:ensure_all_started(jesse),
   ok = add_schemata(Schemata),
   {ok, JsonInstanceBinary} = file:read_file(JsonInstance),
-  JsonInstanceJsx = jsx:decode(JsonInstanceBinary, [{return_maps, false}]),
+  JsonInstanceJsx = ?JSON:decode(JsonInstanceBinary),
   jesse:validate( Schema
                 , JsonInstanceJsx
                 ).
@@ -99,7 +99,7 @@ add_schemata([]) ->
   ok;
 add_schemata([SchemaFile|Rest]) ->
   {ok, SchemaBin} = file:read_file(SchemaFile),
-  Schema0 = jsx:decode(SchemaBin, [{return_maps, false}]),
+  Schema0 = ?JSON:decode(SchemaBin),
   Schema = maybe_fill_schema_id(SchemaFile, Schema0),
   ok = jesse:add_schema(SchemaFile, Schema),
   add_schemata(Rest).

--- a/src/jesse_cli.erl
+++ b/src/jesse_cli.erl
@@ -75,7 +75,7 @@ run(Options, [Schema|_] = Schemata, [JsonInstance|JsonInstances]) ->
     undefined ->
       io:fwrite("~p\n\n", [Result]);
     true ->
-      io:fwrite("~s\n\n", [?JSON:encode(Result)])
+      io:fwrite("~s\n\n", [jesse_lib:json_encode(Result)])
   end,
   case JesseResult of
     {ok, _} ->
@@ -86,11 +86,12 @@ run(Options, [Schema|_] = Schemata, [JsonInstance|JsonInstances]) ->
       halt(1)
   end.
 
+
 jesse_run(JsonInstance, Schema, Schemata) ->
   {ok, _} = application:ensure_all_started(jesse),
   ok = add_schemata(Schemata),
   {ok, JsonInstanceBinary} = file:read_file(JsonInstance),
-  JsonInstanceJsx = ?JSON:decode(JsonInstanceBinary),
+  JsonInstanceJsx = jesse_lib:json_decode(JsonInstanceBinary),
   jesse:validate( Schema
                 , JsonInstanceJsx
                 ).
@@ -99,7 +100,7 @@ add_schemata([]) ->
   ok;
 add_schemata([SchemaFile|Rest]) ->
   {ok, SchemaBin} = file:read_file(SchemaFile),
-  Schema0 = ?JSON:decode(SchemaBin),
+  Schema0 = jesse_lib:json_decode(SchemaBin),
   Schema = maybe_fill_schema_id(SchemaFile, Schema0),
   ok = jesse:add_schema(SchemaFile, Schema),
   add_schemata(Rest).

--- a/src/jesse_database.erl
+++ b/src/jesse_database.erl
@@ -307,7 +307,7 @@ add_file_uri(Key0) ->
   "file://" ++ File = Key,
   {ok, SchemaBin} = file:read_file(File),
   {ok, #file_info{mtime = Mtime}} = file:read_file_info(File),
-  Schema = jsx:decode(SchemaBin, [{return_maps, false}]),
+  Schema = ?JSON:decode(SchemaBin),
   SchemaInfos = [{Key, Mtime, Schema}],
   ValidationFun = fun jesse_lib:is_json_object/1,
   store_schemas(SchemaInfos, ValidationFun).
@@ -321,7 +321,7 @@ add_http_uri(Key0) ->
                                 , HttpOptions
                                 , [{body_format, binary}]),
   {{_Line, 200, _}, Headers, SchemaBin} = Response,
-  Schema = jsx:decode(SchemaBin, [{return_maps, false}]),
+  Schema = ?JSON:decode(SchemaBin),
   SchemaInfos = [{Key, get_http_mtime(Headers), Schema}],
   ValidationFun = fun jesse_lib:is_json_object/1,
   store_schemas(SchemaInfos, ValidationFun).

--- a/src/jesse_database.erl
+++ b/src/jesse_database.erl
@@ -307,7 +307,7 @@ add_file_uri(Key0) ->
   "file://" ++ File = Key,
   {ok, SchemaBin} = file:read_file(File),
   {ok, #file_info{mtime = Mtime}} = file:read_file_info(File),
-  Schema = ?JSON:decode(SchemaBin),
+  Schema = jesse_lib:json_decode(SchemaBin),
   SchemaInfos = [{Key, Mtime, Schema}],
   ValidationFun = fun jesse_lib:is_json_object/1,
   store_schemas(SchemaInfos, ValidationFun).
@@ -321,7 +321,7 @@ add_http_uri(Key0) ->
                                 , HttpOptions
                                 , [{body_format, binary}]),
   {{_Line, 200, _}, Headers, SchemaBin} = Response,
-  Schema = ?JSON:decode(SchemaBin),
+  Schema = jesse_lib:json_decode(SchemaBin),
   SchemaInfos = [{Key, get_http_mtime(Headers), Schema}],
   ValidationFun = fun jesse_lib:is_json_object/1,
   store_schemas(SchemaInfos, ValidationFun).

--- a/src/jesse_error.erl
+++ b/src/jesse_error.erl
@@ -27,7 +27,6 @@
         , handle_data_invalid/3
         , handle_schema_invalid/2
         , to_json/1
-        , to_json/2
         , reason_to_jsx/1
         ]).
 
@@ -105,14 +104,9 @@ handle_schema_invalid(Info, State) ->
 
 %% @doc Convert an error to a JSON string using jsx
 -spec to_json(Error :: error()) -> binary().
-to_json(Error) ->
-  to_json(Error, [indent]).
-
-%% @doc Convert an error to a JSON string using jsx
--spec to_json(Error :: error(), JsxOptions :: [atom()]) -> binary().
-to_json({error, Reasons}, JsxOptions) ->
+to_json({error, Reasons}) ->
   JsxReasons = lists:map(fun reason_to_jsx/1, Reasons),
-  jsx:encode([{reasons, JsxReasons}], JsxOptions).
+  ?JSON:encode([{reasons, JsxReasons}]).
 
 %% @doc Convert an error reason to jsx structs
 -spec reason_to_jsx(Reason :: error_reason()) -> jesse:json_term().

--- a/src/jesse_error.erl
+++ b/src/jesse_error.erl
@@ -106,7 +106,7 @@ handle_schema_invalid(Info, State) ->
 -spec to_json(Error :: error()) -> binary().
 to_json({error, Reasons}) ->
   JsxReasons = lists:map(fun reason_to_jsx/1, Reasons),
-  ?JSON:encode([{reasons, JsxReasons}]).
+  jesse_lib:json_encode([{reasons, JsxReasons}]).
 
 %% @doc Convert an error reason to jsx structs
 -spec reason_to_jsx(Reason :: error_reason()) -> jesse:json_term().

--- a/src/jesse_lib.erl
+++ b/src/jesse_lib.erl
@@ -35,10 +35,35 @@
         , get_schema_id_key/1
         , get_schema_id/1
         , get_schema_id/2
+        , json_encode/1
+        , json_decode/1
         ]).
 
 %% Includes
 -include("jesse_schema_validator.hrl").
+
+%% Use new json library if available
+-ifdef(OTP_RELEASE).
+  -if(?OTP_RELEASE >= 27).
+  %% OTP 27 or higher
+json_decode(Bin) ->
+    json:decode(Bin).
+json_encode(Bin) ->
+    json:encode(Bin).
+  -else.
+  %% OTP 26 to 21.
+json_decode(Bin) ->
+    jsx:decode(Bin).
+json_encode(Bin) ->
+    jsx:encode(Bin).
+  -endif.
+-else.
+  %% OTP 20 or lower.
+json_decode(Bin) ->
+    jsx:decode(Bin).
+json_encode(Bin) ->
+    jsx:encode(Bin).
+-endif.
 
 %%% API
 %% @doc Returns an empty list if the given value is ?not_found.

--- a/src/jesse_lib.erl
+++ b/src/jesse_lib.erl
@@ -53,14 +53,14 @@ json_encode(Bin) ->
   -else.
   %% OTP 26 to 21.
 json_decode(Bin) ->
-    jsx:decode(Bin).
+    jsx:decode(Bin, [{return_maps, false}]).
 json_encode(Bin) ->
     jsx:encode(Bin).
   -endif.
 -else.
   %% OTP 20 or lower.
 json_decode(Bin) ->
-    jsx:decode(Bin).
+    jsx:decode(Bin, [{return_maps, false}]).
 json_encode(Bin) ->
     jsx:encode(Bin).
 -endif.

--- a/src/jesse_schema_validator.hrl
+++ b/src/jesse_schema_validator.hrl
@@ -28,6 +28,20 @@
 -define(IF_MAPS(Exp), Exp).
 -endif.
 
+%% Use new json library if available
+-ifdef(OTP_RELEASE).
+  -if(?OTP_RELEASE >= 27).
+  %% OTP 27 or higher
+    -define(JSON, json).
+  -else.
+  %% OTP 26 to 21.
+    -define(JSON, jsx).
+  -endif.
+-else.
+  %% OTP 20 or lower.
+  -define(JSON, jsx).
+-endif.
+
 %% Use optimization for sets if available
 -ifdef(OTP_RELEASE).
   -if(?OTP_RELEASE >= 24).

--- a/src/jesse_schema_validator.hrl
+++ b/src/jesse_schema_validator.hrl
@@ -28,20 +28,6 @@
 -define(IF_MAPS(Exp), Exp).
 -endif.
 
-%% Use new json library if available
--ifdef(OTP_RELEASE).
-  -if(?OTP_RELEASE >= 27).
-  %% OTP 27 or higher
-    -define(JSON, json).
-  -else.
-  %% OTP 26 to 21.
-    -define(JSON, jsx).
-  -endif.
--else.
-  %% OTP 20 or lower.
-  -define(JSON, jsx).
--endif.
-
 %% Use optimization for sets if available
 -ifdef(OTP_RELEASE).
   -if(?OTP_RELEASE >= 24).

--- a/src/jesse_validator_draft4.erl
+++ b/src/jesse_validator_draft4.erl
@@ -1335,11 +1335,23 @@ remove_last_from_path(State) ->
   jesse_state:remove_last_from_path(State).
 
 %% @private
+-ifdef(OTP_RELEASE).
+%% OTP 21 or higher
 valid_datetime(DateTimeBin) ->
   try calendar:rfc3339_to_system_time(binary_to_list(DateTimeBin)) of
     _ -> true
   catch error:_Error -> false
   end.
+-else.
+%% OTP 20 or lower.
+valid_datetime(DateTimeBin) ->
+  case rfc3339:parse(DateTimeBin) of
+    {ok, _} ->
+      true;
+    _ ->
+      false
+  end.
+-endif.
 
 maybe_external_check_value(Value, State) ->
   case jesse_state:get_external_validator(State) of

--- a/src/jesse_validator_draft4.erl
+++ b/src/jesse_validator_draft4.erl
@@ -1336,11 +1336,9 @@ remove_last_from_path(State) ->
 
 %% @private
 valid_datetime(DateTimeBin) ->
-  case rfc3339:parse(DateTimeBin) of
-    {ok, _} ->
-      true;
-    _ ->
-      false
+  try calendar:rfc3339_to_system_time(binary_to_list(DateTimeBin)) of
+    _ -> true
+  catch error:_Error -> false
   end.
 
 maybe_external_check_value(Value, State) ->

--- a/src/jesse_validator_draft6.erl
+++ b/src/jesse_validator_draft6.erl
@@ -1286,11 +1286,9 @@ remove_last_from_path(State) ->
 
 %% @private
 valid_datetime(DateTimeBin) ->
-  case rfc3339:parse(DateTimeBin) of
-    {ok, _} ->
-      true;
-    _ ->
-      false
+  try calendar:rfc3339_to_system_time(binary_to_list(DateTimeBin)) of
+    _ -> true
+  catch error:_Error -> false
   end.
 
 maybe_external_check_value(Value, State) ->

--- a/src/jesse_validator_draft6.erl
+++ b/src/jesse_validator_draft6.erl
@@ -1285,11 +1285,23 @@ remove_last_from_path(State) ->
   jesse_state:remove_last_from_path(State).
 
 %% @private
+-ifdef(OTP_RELEASE).
+%% OTP 21 or higher
 valid_datetime(DateTimeBin) ->
   try calendar:rfc3339_to_system_time(binary_to_list(DateTimeBin)) of
     _ -> true
   catch error:_Error -> false
   end.
+-else.
+%% OTP 20 or lower.
+valid_datetime(DateTimeBin) ->
+  case rfc3339:parse(DateTimeBin) of
+    {ok, _} ->
+      true;
+    _ ->
+      false
+  end.
+-endif.
 
 maybe_external_check_value(Value, State) ->
   case jesse_state:get_external_validator(State) of


### PR DESCRIPTION
Just trying to minimise the amount of code and dependencies a project gets, OTP covers RFC3339 since 21.0, and json since 27.0. I'd like to slim of dependencies my deployments and OTP's libraries have better support (and performance).

Edit: just wrapped the logic around a `OTP_RELEASE` macro, that way we can keep backwards compatibility.