### PR TITLE
fix: convert `extends` to proplist before checking

### DIFF
--- a/src/jesse_validator_draft3.erl
+++ b/src/jesse_validator_draft3.erl
@@ -903,7 +903,10 @@ check_extends(Value, Extends, State) ->
   TmpState =
     case jesse_lib:is_json_object(Extends) of
       true  ->
-        check_value(Value, Extends, set_current_schema(State, Extends));
+        check_value( Value
+                   , jesse_json_path:unwrap_value(Extends)
+                   , set_current_schema(State, Extends)
+                   );
       false ->
         case is_list(Extends) of
           true  -> check_extends_array(Value, Extends, State);

--- a/test/jesse_tests_draft3_SUITE.erl
+++ b/test/jesse_tests_draft3_SUITE.erl
@@ -135,6 +135,26 @@ uniqueItems(Config) ->
 
 %% Extra
 
+%% The original bug originated from starting from a map schema input, so it was
+%% not triggered by `do_test', which loads the schema as proplists rather than
+%% maps.
+extends_smoke_test(_Config) ->
+  Schema = #{
+             <<"$schema">> => <<"http://json-schema.org/draft-03/schema#">>,
+             <<"description">> => <<"a description">>,
+             <<"extends">> =>
+               #{<<"properties">> =>
+                   #{<<"disallow">> =>
+                       #{<<"disallow">> => [<<"number">>],<<"required">> => true}}},
+             <<"id">> => <<"http://json-schema.org/draft-03/schema#">>,
+             <<"title">> => <<"title">>,
+             <<"type">> => <<"object">>},
+  Data = #{<<"disallow">> => <<"a">>},
+  ?assertEqual({ok, Data}, jesse:validate_with_schema(Schema, Data)).
+
+extendsExtra(Config) ->
+  do_test("extendsExtra", Config).
+
 itemsExtra(Config) ->
   do_test("itemsExtra", Config).
 

--- a/test/jesse_tests_draft3_SUITE_data/extra/extendsExtra.json
+++ b/test/jesse_tests_draft3_SUITE_data/extra/extendsExtra.json
@@ -1,0 +1,33 @@
+[
+  {
+    "description": "simple example using `extends` with `disallow` in the base schema",
+    "schema": {
+      "type": "object",
+      "extends": {
+        "properties": {
+          "disallow": {
+            "disallow": ["number"],
+            "required": true
+          }
+        }
+      }
+    },
+    "tests": [
+      {
+        "description": "valid value: string",
+        "data": {"disallow": "a"},
+        "valid": true
+      },
+      {
+        "description": "valid value: array",
+        "data": {"disallow": ["a", 1]},
+        "valid": true
+      },
+      {
+        "description": "invalid value: number",
+        "data": {"disallow": 1},
+        "valid": false
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Currently, a `function_clause` clause error if one uses the `extends` property with a registered schema.